### PR TITLE
Updated RegEx for URL validation/parsing, to allow relative URLs

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -93,6 +93,9 @@ List of supported events:
 * _newword:composer_ - when the user wrote a new word in the rich text view
 * _destroy:composer_ - when the rich text view gets removed
 * _change_view_ - when switched between source and rich text view
+* _show:dialog_ - when a toolbar dialog is shown
+* _save:dialog_ - when save in a toolbar dialog is clicked
+* _cancel:dialog_ - when cancel in a toolbar dialog is clicked
 
 h2. Progressive-Enhancement/Initialization Step By Step
 

--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -356,7 +356,7 @@ wysihtml5.dom.parse = (function() {
   // ------------ attribute checks ------------ \\
   var attributeCheckMethods = {
     url: (function() {
-      var REG_EXP = /^https?:\/\//i;
+      var REG_EXP = /(?:(?:(https?|file):\/\/)([^\/]+)(\/(?:[^\s])+)?)|(\/(?:[^\s])+)/g;
       return function(attributeValue) {
         if (!attributeValue || !attributeValue.match(REG_EXP)) {
           return null;

--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -78,6 +78,7 @@
 
         dialog.observe("show", function() {
           caretBookmark = wysihtml5.selection.getBookmark(sandboxDoc);
+          that.editor.fire("dialog:show");
         });
 
         dialog.observe("save", function(attributes) {
@@ -87,10 +88,13 @@
             wysihtml5.selection.setBookmark(caretBookmark);
           }
           that._execCommand(command, attributes);
+          
+          that.editor.fire("dialog:save");
         });
 
         dialog.observe("cancel", function() {
           that.editor.focus(false);
+          that.editor.fire("dialog:cancel");
         });
       }
       return dialog;

--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -78,7 +78,7 @@
 
         dialog.observe("show", function() {
           caretBookmark = wysihtml5.selection.getBookmark(sandboxDoc);
-          that.editor.fire("dialog:show");
+          that.editor.fire("show:dialog");
         });
 
         dialog.observe("save", function(attributes) {
@@ -89,12 +89,12 @@
           }
           that._execCommand(command, attributes);
           
-          that.editor.fire("dialog:save");
+          that.editor.fire("save:dialog");
         });
 
         dialog.observe("cancel", function() {
           that.editor.focus(false);
-          that.editor.fire("dialog:cancel");
+          that.editor.fire("cancel:dialog");
         });
       }
       return dialog;


### PR DESCRIPTION
I needed to use relative URLs on a site, to avoid the need to update image URLs if the domain of the site changes.

I've done some initial testing on the updated RegEx, and it seems to work. Let me know if modifications are needed, in order for you to accept the pull request.
