### PR TITLE
Change interpolate interval to avoid touching hidden fields (dialogs)

### DIFF
--- a/src/toolbar/dialog.js
+++ b/src/toolbar/dialog.js
@@ -30,11 +30,12 @@
  *    </script>
  */
 (function(wysihtml5) {
-  var dom                     = wysihtml5.dom,
-      CLASS_NAME_OPENED       = "wysihtml5-command-dialog-opened",
-      SELECTOR_FORM_ELEMENTS  = "input, select, textarea",
-      SELECTOR_FIELDS         = "[data-wysihtml5-dialog-field]",
-      ATTRIBUTE_FIELDS        = "data-wysihtml5-dialog-field";
+  var dom                      = wysihtml5.dom,
+      CLASS_NAME_OPENED        = "wysihtml5-command-dialog-opened",
+      SELECTOR_FORM_ELEMENTS   = "input, select, textarea",
+      SELECTOR_FIELDS          = "[data-wysihtml5-dialog-field]",
+      SELECTOR_FIELDS_NOHIDDEN = "[data-wysihtml5-dialog-field]:not([type=hidden])",
+      ATTRIBUTE_FIELDS         = "data-wysihtml5-dialog-field";
       
   
   wysihtml5.toolbar.Dialog = wysihtml5.lang.Dispatcher.extend(
@@ -131,12 +132,12 @@
      * Basically it adopted the attribute values into the corresponding input fields
      *
      */
-    _interpolate: function() {
+    _interpolate: function(avoidHiddenFields) {
       var field,
           fieldName,
           newValue,
           focusedElement = document.querySelector(":focus"),
-          fields         = this.container.querySelectorAll(SELECTOR_FIELDS),
+          fields         = this.container.querySelectorAll(avoidHiddenFields ? SELECTOR_FIELDS_NOHIDDEN : SELECTOR_FIELDS),
           length         = fields.length,
           i              = 0;
       for (; i<length; i++) {
@@ -161,7 +162,7 @@
       this._observe();
       this._interpolate();
       if (elementToChange) {
-        this.interval = setInterval(function() { that._interpolate(); }, 500);
+        this.interval = setInterval(function() { that._interpolate(true); }, 500);
       }
       dom.addClass(this.link, CLASS_NAME_OPENED);
       this.container.style.display = "";


### PR DESCRIPTION
Avoid touching hidden fields after the first _interpolate. This allows
the use of CMS image libraries, that updates the value of the hidden field.

Before the hidden field would be overwritten every 500ms.
