### PR TITLE
IE currentStyle bug

### DIFF
--- a/src/dom/get_style.js
+++ b/src/dom/get_style.js
@@ -42,7 +42,11 @@ wysihtml5.dom.getStyle = (function() {
         // gives you the original "50%".
         // Opera supports both, currentStyle and window.getComputedStyle, that's why checking for currentStyle should have higher prio
         if (currentStyle) {
-          return currentStyle[camelizedProperty];
+          try {
+                return currentStyle[camelizedProperty];
+          } catch(e) {
+            //ie will occasionally fail for unknown reasons. swallowing exception
+          }
         }
 
         var win                 = doc.defaultView || doc.parentWindow,


### PR DESCRIPTION
Hi, I've found that IE will occasionally die when accessing currentStyle (Does not provide any useful information). Since there are other ways to get the current style one potential fix is to just swallow the exception. It's a little nasty but it works.

Thanks,
James
