### PR TITLE
Specify text of a hyper link when using the createLink command

### DIFF
--- a/src/commands/createLink.js
+++ b/src/commands/createLink.js
@@ -56,7 +56,7 @@
       hasElementChild = !!anchor.querySelector("*");
       isEmpty = textContent === "" || textContent === wysihtml5.INVISIBLE_SPACE;
       if (!hasElementChild && isEmpty) {
-        dom.setTextContent(anchor, anchor.href);
+        dom.setTextContent(anchor, attributes.text || anchor.href);
         whiteSpace = doc.createTextNode(" ");
         wysihtml5.selection.setAfter(anchor);
         wysihtml5.selection.insertNode(whiteSpace);


### PR DESCRIPTION
Allows you to specify the text of a hyper link when executing the createLink command (for #42)

e.g.

``` javascript
editorInstance.composer.commands.exec("createLink", { href: "http://google.com", text: "Google"});
```

There were no unit tests around the createLink command. If you feel this adds enough complexity to warrant tests let me know. 
