### PR TITLE
Support custom attributes on image tags.

### DIFF
--- a/src/commands/insertImage.js
+++ b/src/commands/insertImage.js
@@ -42,7 +42,9 @@
       image = doc.createElement(NODE_NAME);
 
       for (i in value) {
-        image[i] = value[i];
+        var attr = doc.createAttribute(i);
+        attr.nodeValue = value[i];
+        image.setAttributeNode(attr);
       }
 
       composer.selection.insertNode(image);


### PR DESCRIPTION
I had the need to set custom attributes on image tags, but my custom attributes weren't being persisted. This fixes the issue and allows you to set an attribute like `data-max-width` on image tags. Then I can setup my parser rule like so:

``` javascript
"img": {
    "check_attributes": {
        "width": "numbers",
        "alt": "alt",
        "src": "url",
        "height": "numbers",
        "data-max-width": "numbers"
    },
    "add_class": {
        "align": "align_img"
    }
}
```
