### PR TITLE
Set title for img and a tags only if there isn't one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .tm_sync.config
+.idea

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -174,9 +174,11 @@
       if (nodeName !== "A" && nodeName !== "IMG") {
         return;
       }
-
-      title = titlePrefixes[nodeName] + (target.getAttribute("href") || target.getAttribute("src"));
-      target.setAttribute("title", title);
+      var hasTitle = target.hasAttribute("title");
+      if(!hasTitle){
+        title = titlePrefixes[nodeName] + (target.getAttribute("href") || target.getAttribute("src"));
+        target.setAttribute("title", title);
+      }
     });
   };
 })(wysihtml5);


### PR DESCRIPTION
When using title as param example:
wysihtml5.commands.insertImage.exec(composer, "insertImage", { src: "http://www.google.de/logo.jpg", title: "foo" });
The "foo" title gets overiten.
The change is setting a title if there is none set. 
