### PR TITLE
Add absolute path and href sanitizer options

### DIFF
--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -369,6 +369,31 @@ wysihtml5.dom.parse = (function() {
         });
       };
     })(),
+
+    absolute_path: (function() {
+      var REG_EXP = /^\/[\/a-z0-9%?.]*$/i;
+      return function(attributeValue) {
+        if (!attributeValue || !attributeValue.match(REG_EXP)) {
+          return null;
+        }
+        return attributeValue.replace(REG_EXP, function(match) {
+          return match.toLowerCase();
+        });
+      };
+    })(),
+
+    href: (function() {
+      var HTTP_REG_EXP = /^https?:\/\//i;
+      var APATH_REG_EXP = /^\/[\/a-z0-9%?.]*$/i;
+      return function(attributeValue) {
+        if (!attributeValue || (!attributeValue.match(HTTP_REG_EXP) && !attributeValue.match(APATH_REG_EXP))) {
+          return null;
+        }
+        return attributeValue.replace(HTTP_REG_EXP, function(match) {
+          return match.toLowerCase();
+        });
+      };
+    })(),
     
     alt: (function() {
       var REG_EXP = /[^ a-z0-9_\-]/gi;

--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -371,7 +371,7 @@ wysihtml5.dom.parse = (function() {
     })(),
 
     absolute_path: (function() {
-      var REG_EXP = /^\/[\/a-z0-9%?.]*$/i;
+      var REG_EXP = /^\/[\/a-z0-9%?._\-]*$/i;
       return function(attributeValue) {
         if (!attributeValue || !attributeValue.match(REG_EXP)) {
           return null;
@@ -384,7 +384,7 @@ wysihtml5.dom.parse = (function() {
 
     href: (function() {
       var HTTP_REG_EXP = /^https?:\/\//i;
-      var APATH_REG_EXP = /^\/[\/a-z0-9%?.]*$/i;
+      var APATH_REG_EXP = /^\/[\/a-z0-9%?._\-]*$/i;
       return function(attributeValue) {
         if (!attributeValue || (!attributeValue.match(HTTP_REG_EXP) && !attributeValue.match(APATH_REG_EXP))) {
           return null;

--- a/test/dom/parse_test.js
+++ b/test/dom/parse_test.js
@@ -98,17 +98,58 @@ if (wysihtml5.browser.supported()) {
         '<h1 id="main-headline" >take this you snorty little sanitizer</h1>' +
         '<h2>yes, you!</h2>' +
         '<h3>i\'m old and ready to die</h3>' +
-        '<div><video src="pr0n.avi">foobar</video><img src="http://foo.gif" height="10" width="10"></div>' +
+        '<div><video src="pr0n.avi">foobar</video><img src="http://foo.gif" height="10" width="10"><img src="/foo.gif"></div>' +
         '<div><a href="http://www.google.de"></a></div>',
         rules
       ),
       '<h2>take this you snorty little sanitizer</h2>' +
       '<h2>yes, you!</h2>' +
-      '<span><img alt="foo" border="1" src="http://foo.gif" height="10" width="10"></span>' +
+      '<span><img alt="foo" border="1" src="http://foo.gif" height="10" width="10"><img alt="foo" border="1"></span>' +
       '<span><i title=""></i></span>'
     );
   });
 
+  test("Attribute check of absolute_path cleans up", function() {
+    var rules = {
+      tags: {
+        img: {
+          check_attributes: { src: "absolute_path" }
+        }
+      }
+    };
+
+    this.equal(
+      this.sanitize(
+        '<img src="http://url.gif">' +
+        '<img src="/path/to/absolute%20href.gif">' +
+        '<img src="mango time">',
+        rules
+      ),
+      '<img><img src="/path/to/absolute%20href.gif"><img>'
+    );
+  });
+
+  test("Attribute check of href cleans up", function() {
+    var rules = {
+      tags: {
+        img: {
+          check_attributes: { src: "href" }
+        }
+      }
+    };
+
+    this.equal(
+      this.sanitize(
+        '<img src="HTTP://url.gif">' +
+        '<img src="/path/to/absolute%20href.gif">' +
+        '<img src="mango time">',
+        rules
+      ),
+      '<img src="http://url.gif">' +
+      '<img src="/path/to/absolute%20href.gif">' +
+      '<img>'
+    );
+  });
 
   test("Bug in IE8 where invalid html causes duplicated content", function() {
     var rules = {


### PR DESCRIPTION
Howdy!

With tests, this commit adds new `absolute_path` and `href` sanitizer options. I found the `url` option was overly strict, requiring every URL or image src path to have a `/https?:\/\//` start. I'm adding images with `src="/path/is/absolute.gif"`, and there should be a sanitizer that allows that.

I think the `href` option should be the default in the advanced rules as well, but this pull request is conservative and doesn't do that. Let me know if you agree and I can add the commit.

Thanks!
