### PR TITLE
Allow Digits in HTML class names in commands

### DIFF
--- a/src/commands/fontSize.js
+++ b/src/commands/fontSize.js
@@ -5,7 +5,7 @@
  */
 (function(wysihtml5) {
   var undef,
-      REG_EXP = /wysiwyg-font-size-[a-z\-]+/g;
+      REG_EXP = /wysiwyg-font-size-[0-9a-z\-]+/g;
   
   wysihtml5.commands.fontSize = {
     exec: function(composer, command, size) {

--- a/src/commands/foreColor.js
+++ b/src/commands/foreColor.js
@@ -5,7 +5,7 @@
  */
 (function(wysihtml5) {
   var undef,
-      REG_EXP = /wysiwyg-color-[a-z]+/g;
+      REG_EXP = /wysiwyg-color-[0-9a-z]+/g;
   
   wysihtml5.commands.foreColor = {
     exec: function(composer, command, color) {

--- a/src/commands/justifyCenter.js
+++ b/src/commands/justifyCenter.js
@@ -1,7 +1,7 @@
 (function(wysihtml5) {
   var undef,
       CLASS_NAME  = "wysiwyg-text-align-center",
-      REG_EXP     = /wysiwyg-text-align-[a-z]+/g;
+      REG_EXP     = /wysiwyg-text-align-[0-9a-z]+/g;
   
   wysihtml5.commands.justifyCenter = {
     exec: function(composer, command) {

--- a/src/commands/justifyLeft.js
+++ b/src/commands/justifyLeft.js
@@ -1,7 +1,7 @@
 (function(wysihtml5) {
   var undef,
       CLASS_NAME  = "wysiwyg-text-align-left",
-      REG_EXP     = /wysiwyg-text-align-[a-z]+/g;
+      REG_EXP     = /wysiwyg-text-align-[0-9a-z]+/g;
   
   wysihtml5.commands.justifyLeft = {
     exec: function(composer, command) {

--- a/src/commands/justifyRight.js
+++ b/src/commands/justifyRight.js
@@ -1,7 +1,7 @@
 (function(wysihtml5) {
   var undef,
       CLASS_NAME  = "wysiwyg-text-align-right",
-      REG_EXP     = /wysiwyg-text-align-[a-z]+/g;
+      REG_EXP     = /wysiwyg-text-align-[0-9a-z]+/g;
   
   wysihtml5.commands.justifyRight = {
     exec: function(composer, command) {


### PR DESCRIPTION
Changed commands:
- fontSize
- fontColor
- justifyCenter
- justifyLeft
- justifyRight

All these commands are adding classes to some kind of HTML element (such as `<span>`). These classes are supposed to be disjunctive, i.e. there should never be an HTML element with two classes from the same group.

To achieve this behavior, each of the above commands uses an regular expression to remove all the previously added classes before adding the new one.

There's no restriction to prevent class names containing digits from being added. However, the regular expression to remove old class names doesn't match class names containing digits. All in all, we end up with HTML elements with multiple classes from the same command.
