### PR TITLE
added support for boolean attributes

### DIFF
--- a/parser_rules/advanced.js
+++ b/parser_rules/advanced.js
@@ -95,11 +95,12 @@ var wysihtml5ParserRules = {
      *    - set_attributes:     sets/overrides the given attributes
      *
      *    - check_attributes:   checks the given HTML attribute via the given method
-     *                            - url:            allows only valid urls (starting with http:// or https://)
-     *                            - src:            allows something like "/foobar.jpg", "http://google.com", ...
-     *                            - href:           allows something like "mailto:bert@foo.com", "http://google.com", "/foobar.jpg"
-     *                            - alt:            strips unwanted characters. if the attribute is not set, then it gets set (to ensure valid and compatible HTML)
+     *                            - url:      allows only valid urls (starting with http:// or https://)
+     *                            - src:      allows something like "/foobar.jpg", "http://google.com", ...
+     *                            - href:     allows something like "mailto:bert@foo.com", "http://google.com", "/foobar.jpg"
+     *                            - alt:      strips unwanted characters. if the attribute is not set, then it gets set (to ensure valid and compatible HTML)
      *                            - numbers:  ensures that the attribute only contains numeric characters
+     *                            - boolean:  allows truthy values for attributes like checked, selected, autofocus, allowtransparency, etc...
      */
     "tags": {
         "tr": {

--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -233,7 +233,7 @@ wysihtml5.dom.parse = (function() {
         if (!method) {
           continue;
         }
-        newAttributeValue = method(_getAttribute(oldNode, attributeName));
+        newAttributeValue = method(_getAttribute(oldNode, attributeName), attributeName);
         if (typeof(newAttributeValue) === "string") {
           attributes[attributeName] = newAttributeValue;
         }
@@ -402,6 +402,17 @@ wysihtml5.dom.parse = (function() {
           return "";
         }
         return attributeValue.replace(REG_EXP, "");
+      };
+    })(),
+
+    boolean: (function() {
+      var TRUE_REG_EXP = /^(on|true|yes)$/gi;
+      return function(attributeValue, attributeName) {
+        if(attributeValue && (attributeValue.match(TRUE_REG_EXP) || attributeValue.toLowerCase() === attributeName)) {
+          return "";
+        } else {
+          return null;
+        }
       };
     })(),
     

--- a/test/dom/parse_test.js
+++ b/test/dom/parse_test.js
@@ -170,13 +170,6 @@ if (wysihtml5.browser.supported()) {
       }
     };
 
-    alert(this.sanitize(
-        '<input type="text" autofocus="on">' +
-        '<input type="checkbox" checked="checked">' + 
-        '<select><option>A</option><option selected="yes">B</option></select>',
-      rules
-    ));
-
     this.equal(
       this.sanitize(
         '<input type="text" autofocus="on">' +

--- a/test/dom/parse_test.js
+++ b/test/dom/parse_test.js
@@ -151,6 +151,45 @@ if (wysihtml5.browser.supported()) {
     );
   });
 
+  test("Attribute check of booleans", function() {
+    var rules = {
+      tags: {
+        select: true,
+        input: {
+          check_attributes: {
+            type: "alt",
+            autofocus: "boolean",
+            checked: "boolean"
+          }
+        },
+        option: {
+          check_attributes: {
+            selected: "boolean"
+          }
+        }
+      }
+    };
+
+    alert(this.sanitize(
+        '<input type="text" autofocus="on">' +
+        '<input type="checkbox" checked="checked">' + 
+        '<select><option>A</option><option selected="yes">B</option></select>',
+      rules
+    ));
+
+    this.equal(
+      this.sanitize(
+        '<input type="text" autofocus="on">' +
+        '<input type="checkbox" checked="checked">' + 
+        '<select><option>A</option><option selected="yes">B</option></select>',
+        rules
+      ),
+      '<input type="text" autofocus="">' +
+      '<input type="checkbox" checked="">' + 
+      '<select><option>A</option><option selected="">B</option></select>'
+    );
+  });
+
   test("Bug in IE8 where invalid html causes duplicated content", function() {
     var rules = {
       tags: { p: true, span: true, div: true }


### PR DESCRIPTION
Attribute checks in parser rules now supports boolean values like "on", "yes", "true" or attribute name itself. Any other value and even empty value will be evaluated as false. It's useful for attributes like `checked`, `selected`, `autofocus`, etc.

Tests are also included.
