### PR TITLE
Fix DOM classList handling

### DIFF
--- a/src/dom/class.js
+++ b/src/dom/class.js
@@ -1,30 +1,30 @@
 (function(wysihtml5) {
   var supportsClassList = wysihtml5.browser.supportsClassList(),
       api               = wysihtml5.dom;
-  
+
   api.addClass = function(element, className) {
-    if (supportsClassList) {
-      return element.classList.add(className);
+    if (supportsClassList && ((classList = element.classList) != null)) {
+      return classList.add(className);
     }
     if (api.hasClass(element, className)) {
       return;
     }
     element.className += " " + className;
   };
-  
+
   api.removeClass = function(element, className) {
-    if (supportsClassList) {
-      return element.classList.remove(className);
+    if (supportsClassList && ((classList = element.classList) != null)) {
+      return classList.remove(className);
     }
-    
+
     element.className = element.className.replace(new RegExp("(^|\\s+)" + className + "(\\s+|$)"), " ");
   };
-  
+
   api.hasClass = function(element, className) {
-    if (supportsClassList) {
-      return element.classList.contains(className);
+    if (supportsClassList && ((classList = element.classList) != null)) {
+      return classList.contains(className);
     }
-    
+
     var elementClassName = element.className;
     return (elementClassName.length > 0 && (elementClassName == className || new RegExp("(^|\\s)" + className + "(\\s|$)").test(elementClassName)));
   };

--- a/src/dom/class.js
+++ b/src/dom/class.js
@@ -3,6 +3,7 @@
       api               = wysihtml5.dom;
 
   api.addClass = function(element, className) {
+    var classList;
     if (supportsClassList && ((classList = element.classList) != null)) {
       return classList.add(className);
     }
@@ -13,6 +14,7 @@
   };
 
   api.removeClass = function(element, className) {
+    var classList;
     if (supportsClassList && ((classList = element.classList) != null)) {
       return classList.remove(className);
     }
@@ -21,6 +23,7 @@
   };
 
   api.hasClass = function(element, className) {
+    var classList;
     if (supportsClassList && ((classList = element.classList) != null)) {
       return classList.contains(className);
     }


### PR DESCRIPTION
- When the DOMTokenList is empty on Chrome, it returns undefined
- This patch ensures the element classList can be resolved before using it
