### PR TITLE
Add command for justified text alignment

### DIFF
--- a/examples/css/stylesheet.css
+++ b/examples/css/stylesheet.css
@@ -110,6 +110,10 @@
   text-align: left;
 }
 
+.wysiwyg-text-align-justify {
+  text-align: justify;
+}
+
 .wysiwyg-float-left {
   float: left;
   margin: 0 8px 8px 0;

--- a/src/commands/justifyFill.js
+++ b/src/commands/justifyFill.js
@@ -1,0 +1,19 @@
+(function(wysihtml5) {
+  var undef,
+      CLASS_NAME  = "wysiwyg-text-align-justify",
+      REG_EXP     = /wysiwyg-text-align-[0-9a-z]+/g;
+  
+  wysihtml5.commands.justifyFill = {
+    exec: function(composer, command) {
+      return wysihtml5.commands.formatBlock.exec(composer, "formatBlock", null, CLASS_NAME, REG_EXP);
+    },
+
+    state: function(composer, command) {
+      return wysihtml5.commands.formatBlock.state(composer, "formatBlock", null, CLASS_NAME, REG_EXP);
+    },
+
+    value: function() {
+      return undef;
+    }
+  };
+})(wysihtml5);

--- a/test/index.html
+++ b/test/index.html
@@ -65,6 +65,7 @@
 <script src="../src/commands/justifyCenter.js"></script>
 <script src="../src/commands/justifyLeft.js"></script>
 <script src="../src/commands/justifyRight.js"></script>
+<script src="../src/commands/justifyFill.js"></script>
 <script src="../src/commands/redo.js"></script>
 <script src="../src/commands/underline.js"></script>
 <script src="../src/commands/undo.js"></script>


### PR DESCRIPTION
I've added a command for justified text alignment (text-align: justify;).

To avoid confusing naming due to naming conflict with the command prefix, I've named this justifyFill as opposed to justifyJustify, as 'fill' still accurately describes what this setting does.
