### PR TITLE
additional parsing option, conditional parsing and callbacks for attribute checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .tm_sync.config
 .idea
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .tm_sync.config
 .idea
+
+.DS_Store
+
+test/all-tags.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 .tm_sync.config
 .idea
-
-.DS_Store
-
-test/all-tags.html

--- a/dist/wysihtml5-0.3.0.js
+++ b/dist/wysihtml5-0.3.0.js
@@ -4888,7 +4888,7 @@ wysihtml5.dom.parse = (function() {
         nodeName = "div";
       }
     }
-
+    
     if (nodeName in tagRules) {
       rule = tagRules[nodeName];
       method = _checkRules(oldNode, rule);

--- a/dist/wysihtml5-0.3.0.js
+++ b/dist/wysihtml5-0.3.0.js
@@ -3474,13 +3474,6 @@ wysihtml5.browser = (function() {
     hasCurrentStyleProperty: function() {
       return "currentStyle" in testElement;
     },
-    
-    /**
-     * Firefox on OSX navigates through history when hitting CMD + Arrow right/left
-     */
-    hasHistoryIssue: function() {
-      return isGecko;
-    },
 
     /**
      * Whether the browser inserts a <br> when pressing enter in a contentEditable element
@@ -3506,7 +3499,29 @@ wysihtml5.browser = (function() {
     supportsEventsInIframeCorrectly: function() {
       return !isOpera;
     },
+
+    /**
+     * Chrome & Safari only fire the ondrop/ondragend/... events when the ondragover event is cancelled
+     * with event.preventDefault
+     * Firefox 3.6 fires those events anyway, but the mozilla doc says that the dragover/dragenter event needs
+     * to be cancelled
+     */
+    firesOnDropOnlyWhenOnDragOverIsCancelled: function() {
+      return isWebKit || isGecko;
+    },
     
+    /**
+     * Whether the browser supports the event.dataTransfer property in a proper way
+     */
+    supportsDataTransfer: function() {
+      try {
+        // Firefox doesn't support dataTransfer in a safe way, it doesn't strip script code in the html payload (like Chrome does)
+        return isWebKit && (window.Clipboard || window.DataTransfer).prototype.getData;
+      } catch(e) {
+        return false;
+      }
+    },
+
     /**
      * Everything below IE9 doesn't know how to treat HTML5 tags
      *
@@ -3661,6 +3676,14 @@ wysihtml5.browser = (function() {
      */
     supportsSelectionModify: function() {
       return "getSelection" in window && "modify" in window.getSelection();
+    },
+    
+    /**
+     * Whether the browser supports the classList object for fast className manipulation
+     * See https://developer.mozilla.org/en/DOM/element.classList
+     */
+    supportsClassList: function() {
+      return "classList" in testElement;
     },
     
     /**
@@ -4035,12 +4058,12 @@ wysihtml5.browser = (function() {
   // Reveal url reg exp to the outside
   wysihtml5.dom.autoLink.URL_REG_EXP = URL_REG_EXP;
 })(wysihtml5);(function(wysihtml5) {
-  var api = wysihtml5.dom;
+  var supportsClassList = wysihtml5.browser.supportsClassList(),
+      api               = wysihtml5.dom;
   
   api.addClass = function(element, className) {
-    var classList = element.classList;
-    if (classList) {
-      return classList.add(className);
+    if (supportsClassList) {
+      return element.classList.add(className);
     }
     if (api.hasClass(element, className)) {
       return;
@@ -4049,18 +4072,16 @@ wysihtml5.browser = (function() {
   };
   
   api.removeClass = function(element, className) {
-    var classList = element.classList;
-    if (classList) {
-      return classList.remove(className);
+    if (supportsClassList) {
+      return element.classList.remove(className);
     }
     
     element.className = element.className.replace(new RegExp("(^|\\s+)" + className + "(\\s+|$)"), " ");
   };
   
   api.hasClass = function(element, className) {
-    var classList = element.classList;
-    if (classList) {
-      return classList.contains(className);
+    if (supportsClassList) {
+      return element.classList.contains(className);
     }
     
     var elementClassName = element.className;
@@ -4719,42 +4740,6 @@ wysihtml5.dom.observe = function(element, eventNames, handler) {
  *      }
  *    });
  *    // => '<p class="red">foo</p><p>bar</p>'
- *
- *    var userHTML = '<div class="red">foo</div><div class="pink">bar</div>';
- *    wysihtml5.dom.parse(userHTML, {
- *      tags: {
- *        div: {
- *          extract: 1
- *        }
- *      }
- *    });
- *    // => 'foobar'
- *
- *    var userHTML = '<div class="red">foo</div><div class="pink">bar</div>';
- *    wysihtml5.dom.parse(userHTML, {
- *      tags: {
- *        div: {
- *          extract: {
- *             if : { class: "^red|other$" }
- *             ifnot : { class: "^pink$" }
- *          }
- *        }
- *      }
- *    });
- *
- *    // => 'foo<div class="pink">bar</div>'
- *    function myCheck (attr, node) { if (attr == 'localhost') { return '#'; } return attr; }
- *    var userHTML = '<a href="http://google.com">foo</a><a href="localhost">bar</a>';
- *    wysihtml5.dom.parse(userHTML, {
- *      tags: {
- *        a: {
- *          check_attributes: { 
- *            href: { func: 'myCheck' }
- *          }
- *        }
- *      }
- *    });
- *    // => '<a href="http://google.com">foo</a><a href="#">bar</a>'
  */
 wysihtml5.dom.parse = (function() {
   
@@ -4888,91 +4873,28 @@ wysihtml5.dom.parse = (function() {
         nodeName = "div";
       }
     }
-
+    
     if (nodeName in tagRules) {
       rule = tagRules[nodeName];
-      method = _checkRules(oldNode, rule);
-      switch (method) {
-        case 'remove' :
-              return null;
-              break;
-        case 'extract':
-              newNode = oldNode.ownerDocument.createDocumentFragment();
-              break;
-        case 'rename_tag':
-              rule = typeof(rule) === "string" ? { rename_tag: rule } : rule;
-              newNode = oldNode.ownerDocument.createElement(rule.rename_tag || nodeName);
-              break;
-        case 'keep':
-              newNode = oldNode.ownerDocument.createElement(nodeName);
-              break;
+      if (!rule || rule.remove) {
+        return null;
       }
+      
+      rule = typeof(rule) === "string" ? { rename_tag: rule } : rule;
     } else if (oldNode.firstChild) {
       rule = { rename_tag: DEFAULT_NODE_NAME };
-      newNode = oldNode.ownerDocument.createElement(DEFAULT_NODE_NAME);
     } else {
       // Remove empty unknown elements
       return null;
     }
     
+    newNode = oldNode.ownerDocument.createElement(rule.rename_tag || nodeName);
     _handleAttributes(oldNode, newNode, rule);
     
     oldNode = null;
     return newNode;
   }
   
-  /* function _checkRules(node, rules)
-   *
-   * returns the name of the rule which should be applied to the node
-   *
-   * @param node object - the node to check
-   * @param rules mixed - a string or object containing the rules for the node's tag
-   * @return string - name of the rule to apply
-   */
-  function _checkRules (node, rules) {
-    if (typeof(rules) == 'undefined' || !rules) { return 'remove'; }
-    if (typeof(rules) == 'string') { return 'rename_tag'; }
-    
-    var finalRules = [];
-    var priorityOfRules = ['remove', 'extract', 'rename_tag', 'keep'];
-    for(var rule in rules) {
-        if (typeof(rules[rule]) != 'object') { finalRules.push(rule); continue; }
-        var add = true;
-        if (rules[rule].if && !_checkAttributesRules(node, rules[rule].if)) {
-            add = false;
-        }
-        if (add && rules[rule].ifnot && _checkAttributesRules(node, rules[rule].ifnot)) {
-            add = false;
-        }
-        if (add) { finalRules.push(rule); }
-    }
-    var ruleIndex = priorityOfRules.length-1;
-    for (var i = 0; i < finalRules.length; i++) {
-        var ind = priorityOfRules.indexOf(finalRules[i]);
-        if (ind > -1 && ind < ruleIndex) { ruleIndex = ind; }
-    }
-    return priorityOfRules[ruleIndex];
-  }
-
-  /* function _checkAttributesRules (node, setup)
-   *
-   * function checks all attributes set in setup with the corresponding patterns
-   *
-   * @param node object - the node to check
-   * @param setup object - a object where propertyName = node attribute and propertyValue = check pattern
-   * return boolean - whether the node's attributes comply to all patterns or not
-   */
-  function _checkAttributesRules (node, setup) {
-    for (var attrName in setup) {
-        var attr = _getAttribute(node, attrName);
-        var patt = new RegExp(setup[attrName], 'i');
-        if (typeof(attr) === 'undefined' || attr == null || !attr.match(patt)) {
-            return false;
-        }
-    }
-    return true;
-  }
-
   function _handleAttributes(oldNode, newNode, rule) {
     var attributes          = {},                         // fresh new set of attributes to set on newNode
         setClass            = rule.set_class,             // classes to set
@@ -4999,16 +4921,11 @@ wysihtml5.dom.parse = (function() {
     
     if (checkAttributes) {
       for (attributeName in checkAttributes) {
-        if (typeof(checkAttributes[attributeName]) === 'string') {
-            method = attributeCheckMethods[checkAttributes[attributeName]];
-        }
-        if (typeof(checkAttributes[attributeName]) === 'object' && typeof(checkAttributes[attributeName].func) !== 'undefined') {
-            method = window[checkAttributes[attributeName].func];
-        }
+        method = attributeCheckMethods[checkAttributes[attributeName]];
         if (!method) {
           continue;
         }
-        newAttributeValue = method(_getAttribute(oldNode, attributeName), oldNode);
+        newAttributeValue = method(_getAttribute(oldNode, attributeName));
         if (typeof(newAttributeValue) === "string") {
           attributes[attributeName] = newAttributeValue;
         }
@@ -5144,30 +5061,6 @@ wysihtml5.dom.parse = (function() {
         });
       };
     })(),
-
-    src: (function() {
-      var REG_EXP = /^(\/|https?:\/\/)/i;
-      return function(attributeValue) {
-        if (!attributeValue || !attributeValue.match(REG_EXP)) {
-          return null;
-        }
-        return attributeValue.replace(REG_EXP, function(match) {
-          return match.toLowerCase();
-        });
-      };
-    })(),
-
-    href: (function() {
-      var REG_EXP = /^(\/|https?:\/\/|mailto:)/i;
-      return function(attributeValue) {
-        if (!attributeValue || !attributeValue.match(REG_EXP)) {
-          return null;
-        }
-        return attributeValue.replace(REG_EXP, function(match) {
-          return match.toLowerCase();
-        });
-      };
-    })(),
     
     alt: (function() {
       var REG_EXP = /[^ a-z0-9_\-]/gi;
@@ -5243,8 +5136,7 @@ wysihtml5.dom.parse = (function() {
   };
   
   return parse;
-})();
-/**
+})();/**
  * Checks for empty text node childs and removes them
  *
  * @param {Element} node The element in which to cleanup
@@ -5703,12 +5595,10 @@ wysihtml5.dom.replaceWithChildNodes = function(node) {
           if (view.hasPlaceholderSet()) {
             view.clear();
           }
-          view.placeholderSet = false;
           dom.removeClass(view.element, CLASS_NAME);
         },
         set = function() {
           if (view.isEmpty()) {
-            view.placeholderSet = true;
             view.setValue(placeholderText);
             dom.addClass(view.element, CLASS_NAME);
           }
@@ -6242,13 +6132,7 @@ wysihtml5.quirks.cleanPastedHTML = (function() {
       try { newRange.setEnd(rangeBackup.endContainer, rangeBackup.endOffset); } catch(e2) {}
       try { this.setSelection(newRange); } catch(e3) {}
     },
-    
-    set: function(node, offset) {
-      var newRange = rangy.createRange(this.doc);
-      newRange.setStart(node, offset || 0);
-      this.setSelection(newRange);
-    },
-    
+
     /**
      * Insert html at the caret position and move the cursor after the inserted html
      *
@@ -6311,7 +6195,6 @@ wysihtml5.quirks.cleanPastedHTML = (function() {
      */
     scrollIntoView: function() {
       var doc           = this.doc,
-          tolerance     = 5, // px
           hasScrollBars = doc.documentElement.scrollHeight > doc.documentElement.offsetHeight,
           tempElement   = doc._wysihtml5ScrollIntoViewElement = doc._wysihtml5ScrollIntoViewElement || (function() {
             var element = doc.createElement("span");
@@ -6325,7 +6208,7 @@ wysihtml5.quirks.cleanPastedHTML = (function() {
         this.insertNode(tempElement);
         offsetTop = _getCumulativeOffsetTop(tempElement);
         tempElement.parentNode.removeChild(tempElement);
-        if (offsetTop >= (doc.body.scrollTop + doc.documentElement.offsetHeight - tolerance)) {
+        if (offsetTop > doc.body.scrollTop) {
           doc.body.scrollTop = offsetTop;
         }
       }
@@ -6976,7 +6859,7 @@ wysihtml5.Commands = Base.extend(
       return wysihtml5.commands.formatInline.exec(composer, command, "b");
     },
 
-    state: function(composer, command) {
+    state: function(composer, command, color) {
       // element.ownerDocument.queryCommandState("bold") results:
       // firefox: only <b>
       // chrome:  <b>, <strong>, <h1>, <h2>, ...
@@ -7102,7 +6985,7 @@ wysihtml5.Commands = Base.extend(
  */
 (function(wysihtml5) {
   var undef,
-      REG_EXP = /wysiwyg-font-size-[0-9a-z\-]+/g;
+      REG_EXP = /wysiwyg-font-size-[a-z\-]+/g;
   
   wysihtml5.commands.fontSize = {
     exec: function(composer, command, size) {
@@ -7125,7 +7008,7 @@ wysihtml5.Commands = Base.extend(
  */
 (function(wysihtml5) {
   var undef,
-      REG_EXP = /wysiwyg-color-[0-9a-z]+/g;
+      REG_EXP = /wysiwyg-color-[a-z]+/g;
   
   wysihtml5.commands.foreColor = {
     exec: function(composer, command, color) {
@@ -7522,12 +7405,9 @@ wysihtml5.Commands = Base.extend(
       }
 
       image = doc.createElement(NODE_NAME);
-      
+
       for (i in value) {
-        if (i === "className") {
-          i = "class";
-        }
-        image.setAttribute(i, value[i]);
+        image[i] = value[i];
       }
 
       composer.selection.insertNode(image);
@@ -7732,7 +7612,7 @@ wysihtml5.Commands = Base.extend(
       return wysihtml5.commands.formatInline.exec(composer, command, "i");
     },
 
-    state: function(composer, command) {
+    state: function(composer, command, color) {
       // element.ownerDocument.queryCommandState("italic") results:
       // firefox: only <i>
       // chrome:  <i>, <em>, <blockquote>, ...
@@ -7748,7 +7628,7 @@ wysihtml5.Commands = Base.extend(
 })(wysihtml5);(function(wysihtml5) {
   var undef,
       CLASS_NAME  = "wysiwyg-text-align-center",
-      REG_EXP     = /wysiwyg-text-align-[0-9a-z]+/g;
+      REG_EXP     = /wysiwyg-text-align-[a-z]+/g;
   
   wysihtml5.commands.justifyCenter = {
     exec: function(composer, command) {
@@ -7766,7 +7646,7 @@ wysihtml5.Commands = Base.extend(
 })(wysihtml5);(function(wysihtml5) {
   var undef,
       CLASS_NAME  = "wysiwyg-text-align-left",
-      REG_EXP     = /wysiwyg-text-align-[0-9a-z]+/g;
+      REG_EXP     = /wysiwyg-text-align-[a-z]+/g;
   
   wysihtml5.commands.justifyLeft = {
     exec: function(composer, command) {
@@ -7784,7 +7664,7 @@ wysihtml5.Commands = Base.extend(
 })(wysihtml5);(function(wysihtml5) {
   var undef,
       CLASS_NAME  = "wysiwyg-text-align-right",
-      REG_EXP     = /wysiwyg-text-align-[0-9a-z]+/g;
+      REG_EXP     = /wysiwyg-text-align-[a-z]+/g;
   
   wysihtml5.commands.justifyRight = {
     exec: function(composer, command) {
@@ -7799,22 +7679,7 @@ wysihtml5.Commands = Base.extend(
       return undef;
     }
   };
-})(wysihtml5);(function() {
-  var undef;
-  wysihtml5.commands.redo = {
-    exec: function(composer) {
-      return composer.undoManager.redo();
-    },
-
-    state: function(composer) {
-      return false;
-    },
-
-    value: function() {
-      return undef;
-    }
-  };
-})();(function(wysihtml5) {
+})(wysihtml5);(function(wysihtml5) {
   var undef;
   wysihtml5.commands.underline = {
     exec: function(composer, command) {
@@ -7829,22 +7694,7 @@ wysihtml5.Commands = Base.extend(
       return undef;
     }
   };
-})(wysihtml5);(function() {
-  var undef;
-  wysihtml5.commands.undo = {
-    exec: function(composer) {
-      return composer.undoManager.undo();
-    },
-
-    state: function(composer) {
-      return false;
-    },
-
-    value: function() {
-      return undef;
-    }
-  };
-})();/**
+})(wysihtml5);/**
  * Undo Manager for wysihtml5
  * slightly inspired by http://rniwa.com/editing/undomanager.html#the-undomanager-interface
  */
@@ -7853,9 +7703,7 @@ wysihtml5.Commands = Base.extend(
       Y_KEY               = 89,
       BACKSPACE_KEY       = 8,
       DELETE_KEY          = 46,
-      MAX_HISTORY_ENTRIES = 25,
-      DATA_ATTR_NODE      = "data-wysihtml5-selection-node",
-      DATA_ATTR_OFFSET    = "data-wysihtml5-selection-offset",
+      MAX_HISTORY_ENTRIES = 40,
       UNDO_HTML           = '<span id="_wysihtml5-undo" class="_wysihtml5-temp">' + wysihtml5.INVISIBLE_SPACE + '</span>',
       REDO_HTML           = '<span id="_wysihtml5-redo" class="_wysihtml5-temp">' + wysihtml5.INVISIBLE_SPACE + '</span>',
       dom                 = wysihtml5.dom;
@@ -7873,14 +7721,13 @@ wysihtml5.Commands = Base.extend(
       this.editor = editor;
       this.composer = editor.composer;
       this.element = this.composer.element;
+      this.history = [this.composer.getValue()];
+      this.position = 1;
       
-      this.position = 0;
-      this.historyStr = [];
-      this.historyDom = [];
-      
-      this.transact();
-      
-      this._observe();
+      // Undo manager currently only supported in browsers who have the insertHTML command (not IE)
+      if (this.composer.commands.support("insertHTML")) {
+        this._observe();
+      }
     },
     
     _observe: function() {
@@ -7977,124 +7824,46 @@ wysihtml5.Commands = Base.extend(
     },
     
     transact: function() {
-      var previousHtml      = this.historyStr[this.position - 1],
-          currentHtml       = this.composer.getValue();
+      var previousHtml  = this.history[this.position - 1],
+          currentHtml   = this.composer.getValue();
       
-      if (currentHtml === previousHtml) {
+      if (currentHtml == previousHtml) {
         return;
       }
       
-      var length = this.historyStr.length = this.historyDom.length = this.position;
+      var length = this.history.length = this.position;
       if (length > MAX_HISTORY_ENTRIES) {
-        this.historyStr.shift();
-        this.historyDom.shift();
+        this.history.shift();
         this.position--;
       }
       
       this.position++;
-      
-      var range   = this.composer.selection.getRange(),
-          node    = range.startContainer || this.element,
-          offset  = range.startOffset    || 0,
-          element,
-          position;
-      
-      if (node.nodeType === wysihtml5.ELEMENT_NODE) {
-        element = node;
-      } else {
-        element  = node.parentNode;
-        position = this.getChildNodeIndex(element, node);
-      }
-      
-      element.setAttribute(DATA_ATTR_OFFSET, offset);
-      if (typeof(position) !== "undefined") {
-        element.setAttribute(DATA_ATTR_NODE, position);
-      }
-      
-      var clone = this.element.cloneNode(!!currentHtml);
-      this.historyDom.push(clone);
-      this.historyStr.push(currentHtml);
-      
-      element.removeAttribute(DATA_ATTR_OFFSET);
-      element.removeAttribute(DATA_ATTR_NODE);
+      this.history.push(currentHtml);
     },
     
     undo: function() {
       this.transact();
       
-      if (!this.undoPossible()) {
+      if (this.position <= 1) {
         return;
       }
       
-      this.set(this.historyDom[--this.position - 1]);
+      this.set(this.history[--this.position - 1]);
       this.editor.fire("undo:composer");
     },
     
     redo: function() {
-      if (!this.redoPossible()) {
+      if (this.position >= this.history.length) {
         return;
       }
       
-      this.set(this.historyDom[++this.position - 1]);
+      this.set(this.history[++this.position - 1]);
       this.editor.fire("redo:composer");
     },
     
-    undoPossible: function() {
-      return this.position > 1;
-    },
-    
-    redoPossible: function() {
-      return this.position < this.historyStr.length;
-    },
-    
-    set: function(historyEntry) {
-      this.element.innerHTML = "";
-      
-      var i = 0,
-          childNodes = historyEntry.childNodes,
-          length = historyEntry.childNodes.length;
-      
-      for (; i<length; i++) {
-        this.element.appendChild(childNodes[i].cloneNode(true));
-      }
-      
-      // Restore selection
-      var offset,
-          node,
-          position;
-      
-      if (historyEntry.hasAttribute(DATA_ATTR_OFFSET)) {
-        offset    = historyEntry.getAttribute(DATA_ATTR_OFFSET);
-        position  = historyEntry.getAttribute(DATA_ATTR_NODE);
-        node      = this.element;
-      } else {
-        node      = this.element.querySelector("[" + DATA_ATTR_OFFSET + "]") || this.element;
-        offset    = node.getAttribute(DATA_ATTR_OFFSET);
-        position  = node.getAttribute(DATA_ATTR_NODE);
-        node.removeAttribute(DATA_ATTR_OFFSET);
-        node.removeAttribute(DATA_ATTR_NODE);
-      }
-      
-      if (position !== null) {
-        node = this.getChildNodeByIndex(node, +position);
-      }
-      
-      this.composer.selection.set(node, offset);
-    },
-    
-    getChildNodeIndex: function(parent, child) {
-      var i           = 0,
-          childNodes  = parent.childNodes,
-          length      = childNodes.length;
-      for (; i<length; i++) {
-        if (childNodes[i] === child) {
-          return i;
-        }
-      }
-    },
-    
-    getChildNodeByIndex: function(parent, index) {
-      return parent.childNodes[index];
+    set: function(html) {
+      this.composer.setValue(html);
+      this.editor.focus(true);
     }
   });
 })(wysihtml5);
@@ -8244,7 +8013,7 @@ wysihtml5.views.View = Base.extend(
     },
 
     hasPlaceholderSet: function() {
-      return this.getTextContent() == this.textarea.element.getAttribute("placeholder") && this.placeholderSet;
+      return this.getTextContent() == this.textarea.element.getAttribute("placeholder");
     },
 
     isEmpty: function() {
@@ -8265,18 +8034,17 @@ wysihtml5.views.View = Base.extend(
         stylesheets:  this.config.stylesheets
       });
       this.iframe  = this.sandbox.getIframe();
-      
+
+      // Create hidden field which tells the server after submit, that the user used an wysiwyg editor
+      var hiddenField = document.createElement("input");
+      hiddenField.type   = "hidden";
+      hiddenField.name   = "_wysihtml5_mode";
+      hiddenField.value  = 1;
+
+      // Store reference to current wysihtml5 instance on the textarea element
       var textareaElement = this.textarea.element;
       dom.insert(this.iframe).after(textareaElement);
-      
-      // Create hidden field which tells the server after submit, that the user used an wysiwyg editor
-      if (textareaElement.form) {
-        var hiddenField = document.createElement("input");
-        hiddenField.type   = "hidden";
-        hiddenField.name   = "_wysihtml5_mode";
-        hiddenField.value  = 1;
-        dom.insert(hiddenField).after(textareaElement);
-      }
+      dom.insert(hiddenField).after(textareaElement);
     },
 
     _create: function() {
@@ -8330,7 +8098,7 @@ wysihtml5.views.View = Base.extend(
 
       // Simulate html5 autofocus on contentEditable element
       if (this.textarea.element.hasAttribute("autofocus") || document.querySelector(":focus") == this.textarea.element) {
-        setTimeout(function() { that.focus(true); }, 100);
+        setTimeout(function() { that.focus(); }, 100);
       }
 
       wysihtml5.quirks.insertLineBreakOnReturn(this);
@@ -8460,7 +8228,7 @@ wysihtml5.views.View = Base.extend(
     },
     
     _initUndoManager: function() {
-      this.undoManager = new wysihtml5.UndoManager(this.parent);
+      new wysihtml5.UndoManager(this.parent);
     }
   });
 })(wysihtml5);(function(wysihtml5) {
@@ -8679,7 +8447,8 @@ wysihtml5.views.View = Base.extend(
         iframe              = this.sandbox.getIframe(),
         element             = this.element,
         focusBlurElement    = browser.supportsEventsInIframeCorrectly() ? element : this.sandbox.getWindow(),
-        pasteEvents         = ["drop", "paste"];
+        // Firefox < 3.5 doesn't support the drop event, instead it supports a so called "dragdrop" event which behaves almost the same
+        pasteEvents         = browser.supportsEvent("drop") ? ["drop", "paste"] : ["dragdrop", "paste"];
 
     // --------- destroy:composer event ---------
     dom.observe(iframe, "DOMNodeRemoved", function() {
@@ -8737,10 +8506,30 @@ wysihtml5.views.View = Base.extend(
       that.parent.fire("unset_placeholder");
     });
 
+    if (browser.firesOnDropOnlyWhenOnDragOverIsCancelled()) {
+      dom.observe(element, ["dragover", "dragenter"], function(event) {
+        event.preventDefault();
+      });
+    }
+
     dom.observe(element, pasteEvents, function(event) {
-      setTimeout(function() {
+      var dataTransfer = event.dataTransfer,
+          data;
+
+      if (dataTransfer && browser.supportsDataTransfer()) {
+        data = dataTransfer.getData("text/html") || dataTransfer.getData("text/plain");
+      }
+      if (data) {
+        element.focus();
+        that.commands.exec("insertHTML", data);
         that.parent.fire("paste").fire("paste:composer");
-      }, 0);
+        event.stopPropagation();
+        event.preventDefault();
+      } else {
+        setTimeout(function() {
+          that.parent.fire("paste").fire("paste:composer");
+        }, 0);
+      }
     });
 
     // --------- neword event ---------
@@ -8761,34 +8550,6 @@ wysihtml5.views.View = Base.extend(
         var target = event.target;
         if (target.nodeName === "IMG") {
           that.selection.selectNode(target);
-          event.preventDefault();
-        }
-      });
-    }
-    
-    if (browser.hasHistoryIssue() && wysihtml5.browser.supportsSelectionModify()) {
-      dom.observe(element, "keydown", function(event) {
-        if (!event.metaKey && !event.ctrlKey) {
-          return;
-        }
-        
-        var keyCode   = event.keyCode,
-            win       = element.ownerDocument.defaultView,
-            selection = win.getSelection();
-        
-        if (keyCode === 37 || keyCode === 39) {
-          if (keyCode === 37) {
-            selection.modify("extend", "left", "lineboundary");
-            if (!event.shiftKey) {
-              selection.collapseToStart();
-            }
-          }
-          if (keyCode === 39) {
-            selection.modify("extend", "right", "lineboundary");
-            if (!event.shiftKey) {
-              selection.collapseToEnd();
-            }
-          }
           event.preventDefault();
         }
       });
@@ -9169,10 +8930,6 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
      * Show the dialog element
      */
     show: function(elementToChange) {
-      if (dom.hasClass(this.link, CLASS_NAME_OPENED)) {
-        return;
-      }
-      
       var that        = this,
           firstField  = this.container.querySelector(SELECTOR_FORM_ELEMENTS);
       this.elementToChange = elementToChange;
@@ -9257,11 +9014,7 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
       link.style.display = "none";
       return;
     }
-    var lang = parent.editor.textarea.element.getAttribute("lang");
-    if (lang) {
-      inputAttributes.lang = lang;
-    }
-
+    
     var wrapper = document.createElement("div");
     
     wysihtml5.lang.object(wrapperStyles).merge({
@@ -9273,7 +9026,7 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
     dom.insert(wrapper).into(link);
     
     dom.setStyles(inputStyles).on(input);
-    dom.setAttributes(inputAttributes).on(input);
+    dom.setAttributes(inputAttributes).on(input)
     
     dom.setStyles(wrapperStyles).on(wrapper);
     dom.setStyles(linkStyles).on(link);
@@ -9455,8 +9208,8 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
         }).on(links[i]);
       }
 
-      // Needed for opera and chrome
-      dom.delegate(container, "[data-wysihtml5-command], [data-wysihtml5-action]", "mousedown", function(event) { event.preventDefault(); });
+      // Needed for opera
+      dom.delegate(container, "[data-wysihtml5-command]", "mousedown", function(event) { event.preventDefault(); });
       
       dom.delegate(container, "[data-wysihtml5-command]", "click", function(event) {
         var link          = this,
@@ -9699,12 +9452,9 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
     },
 
     setValue: function(html, parse) {
-      this.fire("unset_placeholder");
-      
       if (!html) {
         return this.clear();
       }
-      
       this.currentView.setValue(html, parse);
       return this;
     },

--- a/dist/wysihtml5-0.3.0.js
+++ b/dist/wysihtml5-0.3.0.js
@@ -4888,7 +4888,7 @@ wysihtml5.dom.parse = (function() {
         nodeName = "div";
       }
     }
-    
+
     if (nodeName in tagRules) {
       rule = tagRules[nodeName];
       method = _checkRules(oldNode, rule);

--- a/parser_rules/advanced.js
+++ b/parser_rules/advanced.js
@@ -1,6 +1,6 @@
 /**
  * Full HTML5 compatibility rule set
- * These rules define which tags and CSS classes are supported and which tags should be specially treated.
+ * These rules define which tags and css classes are supported and which tags should be specially treated.
  *
  * Examples based on this rule set:
  *
@@ -18,7 +18,7 @@
  *
  *    <marquee>foo</marquee>
  *    ... becomes ...
- *    <span>foo</span>
+ *    <span>foo</marquee>
  *
  *    foo <br clear="both"> bar
  *    ... becomes ...
@@ -35,7 +35,7 @@
 var wysihtml5ParserRules = {
     /**
      * CSS Class white-list
-     * Following CSS classes won't be removed when parsed by the wysihtml5 HTML parser
+     * Following css classes won't be removed when parsed by the wysihtml5 html parser
      */
     "classes": {
         "wysiwyg-clear-both": 1,
@@ -71,483 +71,381 @@ var wysihtml5ParserRules = {
         "wysiwyg-text-align-center": 1,
         "wysiwyg-text-align-justify": 1,
         "wysiwyg-text-align-left": 1,
-        "wysiwyg-text-align-right": 1
+        "wysiwyg-text-align-right": 1,
     },
     /**
      * Tag list
      *
-     * The following options are available:
+     * Following options are available:
      *
      *    - add_class:        converts and deletes the given HTML4 attribute (align, clear, ...) via the given method to a css class
      *                        The following methods are implemented in wysihtml5.dom.parse:
      *                          - align_text:  converts align attribute values (right/left/center/justify) to their corresponding css class "wysiwyg-text-align-*")
-     *                            <p align="center">foo</p> ... becomes ... <p> class="wysiwyg-text-align-center">foo</p>
+                                  <p align="center">foo</p> ... becomes ... <p> class="wysiwyg-text-align-center">foo</p>
      *                          - clear_br:    converts clear attribute values left/right/all/both to their corresponding css class "wysiwyg-clear-*"
      *                            <br clear="all"> ... becomes ... <br class="wysiwyg-clear-both">
      *                          - align_img:    converts align attribute values (right/left) on <img> to their corresponding css class "wysiwyg-float-*"
      *                          
-     *    - remove:             removes the element and its content
+     *    - remove:             removes the element and it's content
      *
      *    - rename_tag:         renames the element to the given tag
+     *    
+     *    - extract:            extract the content of the tag and it to the parent node
+     *
+     *    - keep:               do nothing (same as 1 or {})
+     *
+     *    conditioning with if and ifnot: you can have all the above actions execute on conditions of specific attributes of the node
+     *            
+     *                          syntax: Object { option(remove|rename_tag|extract|keep) : {
+     *                                                  "if"    : { nodeAttribute : regExpMatchPattern }
+     *                                                  "ifnot" : { nodeAttribute : regExpMatchPattern }
+     *                                           }
+     *                                         }
+     *                          example: "extract" : {
+     *                                                 "ifnot" : { "class" : "^(columnised|column)$" }
+     *                                               }                          
      *
      *    - set_class:          adds the given class to the element (note: make sure that the class is in the "classes" white list above)
      *
      *    - set_attributes:     sets/overrides the given attributes
      *
      *    - check_attributes:   checks the given HTML attribute via the given method
-     *                            - url:            allows only valid urls (starting with http:// or https://)
-     *                            - src:            allows something like "/foobar.jpg", "http://google.com", ...
-     *                            - href:           allows something like "mailto:bert@foo.com", "http://google.com", "/foobar.jpg"
-     *                            - alt:            strips unwanted characters. if the attribute is not set, then it gets set (to ensure valid and compatible HTML)
+     *                            - url:      checks whether the given string is an url, deletes the attribute if not
+     *                            - alt:      strips unwanted characters. if the attribute is not set, then it gets set (to ensure valid and compatible HTML)
      *                            - numbers:  ensures that the attribute only contains numeric characters
+     *                            - { func: yourGlobalFunctionName }: calls the global function with (attr, node) as values; return non-string to remove attribute
      */
     "tags": {
-        "tr": {
-            "add_class": {
-                "align": "align_text"
-            }
+        "a": {
+            "check_attributes": {
+                "href"   : "url",
+                "rel"    : { 'func' : 'checkLinkRelation' },
+                "target" : { 'func' : 'checkLinkTarget' }
+            },
         },
-        "strike": {
-            "remove": 1
-        },
-        "form": {
-            "rename_tag": "div"
-        },
-        "rt": {
-            "rename_tag": "span"
-        },
-        "code": {},
+        "abbr": 1,
         "acronym": {
-            "rename_tag": "span"
+            "rename_tag": "abbr"
         },
-        "br": {
-            "add_class": {
-                "clear": "clear_br"
-            }
+        "address": {
+            "rename_tag": "p"
         },
-        "details": {
-            "rename_tag": "div"
-        },
-        "h4": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "em": {},
-        "title": {
+        "applet": {
             "remove": 1
-        },
-        "multicol": {
-            "rename_tag": "div"
-        },
-        "figure": {
-            "rename_tag": "div"
-        },
-        "xmp": {
-            "rename_tag": "span"
-        },
-        "small": {
-            "rename_tag": "span",
-            "set_class": "wysiwyg-font-size-smaller"
         },
         "area": {
             "remove": 1
         },
-        "time": {
-            "rename_tag": "span"
+        "article": {
+            "rename_tag": "p"
         },
-        "dir": {
-            "rename_tag": "ul"
+        "aside": {
+            "extract": 1
         },
-        "bdi": {
-            "rename_tag": "span"
-        },
-        "command": {
+        "audio": {
             "remove": 1
         },
-        "ul": {},
-        "progress": {
-            "rename_tag": "span"
-        },
-        "dfn": {
-            "rename_tag": "span"
-        },
-        "iframe": {
+        "b": 1,
+        "base": {
             "remove": 1
-        },
-        "figcaption": {
-            "rename_tag": "div"
-        },
-        "a": {
-            "check_attributes": {
-                "href": "href"
-            },
-            "set_attributes": {
-                "rel": "nofollow",
-                "target": "_blank"
-            }
-        },
-        "img": {
-            "check_attributes": {
-                "width": "numbers",
-                "alt": "alt",
-                "src": "src",
-                "height": "numbers"
-            },
-            "add_class": {
-                "align": "align_img"
-            }
-        },
-        "rb": {
-            "rename_tag": "span"
-        },
-        "footer": {
-            "rename_tag": "div"
-        },
-        "noframes": {
-            "remove": 1
-        },
-        "abbr": {
-            "rename_tag": "span"
-        },
-        "u": {},
-        "bgsound": {
-            "remove": 1
-        },
-        "sup": {
-            "rename_tag": "span"
-        },
-        "address": {
-            "rename_tag": "div"
         },
         "basefont": {
             "remove": 1
         },
-        "nav": {
-            "rename_tag": "div"
+        "bdi": 1,
+        "bdo": 1,
+        "bgsound": {
+            "remove": 1
+        },
+        "big": {
+            "rename_tag": "strong"
+        },
+        "blink": {
+            "rename_tag": "strong"
+        },
+        "blockquote": {
+            "rename_tag": "p"
+        },
+        "body": {
+            "extract": 1
+        },
+        "br": 1,
+        "button": { "remove": 1 },
+        "canvas": {
+            "remove": 1
+        },
+        "caption": {
+            "rename_tag": "p",
+        },
+        "center": {
+            "rename_tag": "p",
+        },
+        "cite": 1,
+        "code": 1,
+        "col": {
+            "remove": 1
+        },
+        "colgroup": {
+            "remove": 1
+        },
+        "command": {
+            "remove": 1
+        },
+        "comment": {
+            "rename_tag": "p"
+        },
+        "datalist": {
+            "rename_tag": "ul"
+        },
+        "del": 1,
+        "details": {
+            "rename_tag": "p"
+        },
+        "device": {
+            "remove": 1
+        },
+        "dfn": 1,
+        "dir": {
+            "rename_tag": "ul"
+        },
+        "div": {
+            "extract" : {
+                "ifnot" : { "class" : "^(columnised|column)$" }
+            }
+        },
+        "dd": 1,
+        "dl": 1,
+        "dt": 1,
+        "em": 1,
+        "embed": {
+            "remove": 1
+        },
+        "fieldset": {
+            "extract": 1
+        },
+        "figcaption": {
+            "extract": 1
+        },
+        "figure": {
+            "extract": 1
+        },
+        "frameset": {
+            "remove": 1
+        },
+        "font": {
+            "extract": 1
+        },
+        "footer": {
+            "extract": 1
+        },
+        "form": {
+            "extract": 1
+        },
+        "frame": {
+            "remove": 1
         },
         "h1": {
-            "add_class": {
-                "align": "align_text"
-            }
+            "rename_tag": "h3"
+        },
+        "h2": {
+            "rename_tag": "h3"
+        },
+        "h3": 1,
+        "h4": 1,
+        "h5": 1,
+        "h6": 1,
+        "header": {
+            "rename_tag": "p"
         },
         "head": {
             "remove": 1
         },
-        "tbody": {
-            "add_class": {
-                "align": "align_text"
-            }
+        "hgroup": {
+            "extract": 1
         },
-        "dd": {
-            "rename_tag": "div"
-        },
-        "s": {
-            "rename_tag": "span"
-        },
-        "li": {},
-        "td": {
-            "check_attributes": {
-                "rowspan": "numbers",
-                "colspan": "numbers"
-            },
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "object": {
-            "remove": 1
-        },
-        "div": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "option": {
-            "rename_tag": "span"
-        },
-        "select": {
-            "rename_tag": "span"
+        "hr": 1,
+        "html": {
+            "extract": 1
         },
         "i": {},
-        "track": {
+        "iframe": {
+            "extract": 1
+        },
+        "img": {
             "remove": 1
         },
-        "wbr": {
-            "remove": 1
-        },
-        "fieldset": {
-            "rename_tag": "div"
-        },
-        "big": {
-            "rename_tag": "span",
-            "set_class": "wysiwyg-font-size-larger"
-        },
-        "button": {
-            "rename_tag": "span"
-        },
-        "noscript": {
-            "remove": 1
-        },
-        "svg": {
-            "remove": 1
-        },
-        "input": {
-            "remove": 1
-        },
-        "table": {},
-        "keygen": {
-            "remove": 1
-        },
-        "h5": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "meta": {
-            "remove": 1
-        },
-        "map": {
-            "rename_tag": "div"
-        },
+        "input": { "remove": 1 },
+        "ins": 1,
         "isindex": {
             "remove": 1
         },
+        "keygen": {
+            "remove": 1
+        },
+        "kbd": 1,
+        "label": {
+            "extract": 1
+        },
+        "legend": {
+            "rename_tag": "strong"
+        },
+        "li": 1,
+        "link": {
+            "remove": 1
+        },
+        "listing": {
+            "extract": 1
+        },
+        "map": {
+            "remove": 1
+        },
         "mark": {
-            "rename_tag": "span"
-        },
-        "caption": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "tfoot": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "base": {
-            "remove": 1
-        },
-        "video": {
-            "remove": 1
-        },
-        "strong": {},
-        "canvas": {
-            "remove": 1
-        },
-        "output": {
-            "rename_tag": "span"
+            "rename_tag": "em"
         },
         "marquee": {
-            "rename_tag": "span"
+            "rename_tag": "em"
         },
-        "b": {},
+        "menu": {
+            "rename_tag": "ul"
+        },
+        "meta": { "remove": 1 },
+        "meter": {
+            "extract": 1
+        },
+        "multicol": {
+            "rename_tag": "div",
+            "add_class" : "columnised"
+        },
+        "nav": {
+            "rename_tag": "p"
+        },
+        "nextid": {
+            "remove": 1
+        },
+        "nobr": {
+            "rename_tag": "code"
+        },
+        "noembed": {
+            "remove": 1
+        },
+        "noframes": {
+            "remove": 1
+        },
+        "noscript": { "remove": 1 },
+        "object": {
+            "remove": 1
+        },
+        "ol": 1,
+        "optgroup": {
+            "rename_tag": "p"
+        },
+        "option": {
+            "rename_tag": "li"
+        },
+        "output": {
+            "rename_tag": "p"
+        },
+        "p": 1,
+        "param": {
+            "remove": 1
+        },
+        "plaintext": {
+            "rename_tag": "p"
+        },
+        "pre": {
+            "rename_tag": "p"
+        },
+        "progress": {
+            "remove": 1
+        },
         "q": {
             "check_attributes": {
                 "cite": "url"
             }
         },
-        "applet": {
-            "remove": 1
-        },
-        "span": {},
-        "rp": {
-            "rename_tag": "span"
-        },
-        "spacer": {
-            "remove": 1
-        },
-        "source": {
-            "remove": 1
-        },
-        "aside": {
-            "rename_tag": "div"
-        },
-        "frame": {
-            "remove": 1
-        },
-        "section": {
-            "rename_tag": "div"
-        },
-        "body": {
-            "rename_tag": "div"
-        },
-        "ol": {},
-        "nobr": {
-            "rename_tag": "span"
-        },
-        "html": {
-            "rename_tag": "div"
-        },
-        "summary": {
-            "rename_tag": "span"
-        },
-        "var": {
-            "rename_tag": "span"
-        },
-        "del": {
-            "remove": 1
-        },
-        "blockquote": {
-            "check_attributes": {
-                "cite": "url"
-            }
-        },
-        "style": {
-            "remove": 1
-        },
-        "device": {
-            "remove": 1
-        },
-        "meter": {
-            "rename_tag": "span"
-        },
-        "h3": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "textarea": {
-            "rename_tag": "span"
-        },
-        "embed": {
-            "remove": 1
-        },
-        "hgroup": {
-            "rename_tag": "div"
-        },
-        "font": {
-            "rename_tag": "span",
-            "add_class": {
-                "size": "size_font"
-            }
-        },
-        "tt": {
-            "rename_tag": "span"
-        },
-        "noembed": {
-            "remove": 1
-        },
-        "thead": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "blink": {
-            "rename_tag": "span"
-        },
-        "plaintext": {
-            "rename_tag": "span"
-        },
-        "xml": {
-            "remove": 1
-        },
-        "h6": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "param": {
-            "remove": 1
-        },
-        "th": {
-            "check_attributes": {
-                "rowspan": "numbers",
-                "colspan": "numbers"
-            },
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "legend": {
-            "rename_tag": "span"
-        },
-        "hr": {},
-        "label": {
-            "rename_tag": "span"
-        },
-        "dl": {
-            "rename_tag": "div"
-        },
-        "kbd": {
-            "rename_tag": "span"
-        },
-        "listing": {
-            "rename_tag": "div"
-        },
-        "dt": {
-            "rename_tag": "span"
-        },
-        "nextid": {
-            "remove": 1
-        },
-        "pre": {},
-        "center": {
-            "rename_tag": "div",
-            "set_class": "wysiwyg-text-align-center"
-        },
-        "audio": {
-            "remove": 1
-        },
-        "datalist": {
-            "rename_tag": "span"
-        },
+        "rb": 1,
+        "rp": 1,
+        "rt": 1,
+        "ruby": 1,
+        "s": 1,
         "samp": {
-            "rename_tag": "span"
-        },
-        "col": {
-            "remove": 1
-        },
-        "article": {
-            "rename_tag": "div"
-        },
-        "cite": {},
-        "link": {
-            "remove": 1
+            "rename_tag": "code"
         },
         "script": {
             "remove": 1
         },
-        "bdo": {
-            "rename_tag": "span"
-        },
-        "menu": {
+        "select": {
             "rename_tag": "ul"
         },
-        "colgroup": {
+        "section": {
+            "extract": 1
+        },
+        "small": {
+            "extract": 1,
+        },
+        "source": {
             "remove": 1
         },
-        "ruby": {
-            "rename_tag": "span"
-        },
-        "h2": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "ins": {
-            "rename_tag": "span"
-        },
-        "p": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "sub": {
-            "rename_tag": "span"
-        },
-        "comment": {
+        "spacer": {
             "remove": 1
         },
-        "frameset": {
+        "span": { "extract": 1 },
+        "strike": {
+            "rename_tag": "del"
+        },
+        "strong": 1,
+        "style": {
             "remove": 1
         },
-        "optgroup": {
-            "rename_tag": "span"
+        "sub": 1,
+        "sup": 1,
+        "svg": { "remove": 1 },
+        "table": { "remove": 1 },
+        "tbody": { "remove": 1 },
+        "textarea": {
+            "rename_tag": "p"
         },
-        "header": {
-            "rename_tag": "div"
-        }
+        "td": {
+            "remove": 1
+        },
+        "tfoot": {
+            "rename_tag": "p"
+        },
+        "th": {
+            "rename_tag": "strong"
+        },
+        "thead": {
+            "rename_tag": "p"
+        },
+        "time": 1,
+        "title": {
+            "remove": 1
+        },
+        "tr": {
+            "rename_tag": "p"
+        },
+        "track": {
+            "remove": 1
+        },
+        "tt": {
+            "rename_tag": "blockquote"
+        },
+        "u": {
+            "extract": 1
+        },
+        "ul": 1,
+        "var": 1,
+        "video": {
+            "remove": 1
+        },
+        "wbr": {
+            "remove": 1
+        },
+        "xml": {
+            "remove": 1
+        },
+        "xmp": {
+            "rename_tag": "p"
+        },
     }
 };

--- a/parser_rules/advanced.js
+++ b/parser_rules/advanced.js
@@ -1,6 +1,6 @@
 /**
  * Full HTML5 compatibility rule set
- * These rules define which tags and css classes are supported and which tags should be specially treated.
+ * These rules define which tags and CSS classes are supported and which tags should be specially treated.
  *
  * Examples based on this rule set:
  *
@@ -18,7 +18,7 @@
  *
  *    <marquee>foo</marquee>
  *    ... becomes ...
- *    <span>foo</marquee>
+ *    <span>foo</span>
  *
  *    foo <br clear="both"> bar
  *    ... becomes ...
@@ -35,7 +35,7 @@
 var wysihtml5ParserRules = {
     /**
      * CSS Class white-list
-     * Following css classes won't be removed when parsed by the wysihtml5 html parser
+     * Following CSS classes won't be removed when parsed by the wysihtml5 HTML parser
      */
     "classes": {
         "wysiwyg-clear-both": 1,
@@ -71,381 +71,483 @@ var wysihtml5ParserRules = {
         "wysiwyg-text-align-center": 1,
         "wysiwyg-text-align-justify": 1,
         "wysiwyg-text-align-left": 1,
-        "wysiwyg-text-align-right": 1,
+        "wysiwyg-text-align-right": 1
     },
     /**
      * Tag list
      *
-     * Following options are available:
+     * The following options are available:
      *
      *    - add_class:        converts and deletes the given HTML4 attribute (align, clear, ...) via the given method to a css class
      *                        The following methods are implemented in wysihtml5.dom.parse:
      *                          - align_text:  converts align attribute values (right/left/center/justify) to their corresponding css class "wysiwyg-text-align-*")
-                                  <p align="center">foo</p> ... becomes ... <p> class="wysiwyg-text-align-center">foo</p>
+     *                            <p align="center">foo</p> ... becomes ... <p> class="wysiwyg-text-align-center">foo</p>
      *                          - clear_br:    converts clear attribute values left/right/all/both to their corresponding css class "wysiwyg-clear-*"
      *                            <br clear="all"> ... becomes ... <br class="wysiwyg-clear-both">
      *                          - align_img:    converts align attribute values (right/left) on <img> to their corresponding css class "wysiwyg-float-*"
      *                          
-     *    - remove:             removes the element and it's content
+     *    - remove:             removes the element and its content
      *
      *    - rename_tag:         renames the element to the given tag
-     *    
-     *    - extract:            extract the content of the tag and it to the parent node
-     *
-     *    - keep:               do nothing (same as 1 or {})
-     *
-     *    conditioning with if and ifnot: you can have all the above actions execute on conditions of specific attributes of the node
-     *            
-     *                          syntax: Object { option(remove|rename_tag|extract|keep) : {
-     *                                                  "if"    : { nodeAttribute : regExpMatchPattern }
-     *                                                  "ifnot" : { nodeAttribute : regExpMatchPattern }
-     *                                           }
-     *                                         }
-     *                          example: "extract" : {
-     *                                                 "ifnot" : { "class" : "^(columnised|column)$" }
-     *                                               }                          
      *
      *    - set_class:          adds the given class to the element (note: make sure that the class is in the "classes" white list above)
      *
      *    - set_attributes:     sets/overrides the given attributes
      *
      *    - check_attributes:   checks the given HTML attribute via the given method
-     *                            - url:      checks whether the given string is an url, deletes the attribute if not
-     *                            - alt:      strips unwanted characters. if the attribute is not set, then it gets set (to ensure valid and compatible HTML)
+     *                            - url:            allows only valid urls (starting with http:// or https://)
+     *                            - src:            allows something like "/foobar.jpg", "http://google.com", ...
+     *                            - href:           allows something like "mailto:bert@foo.com", "http://google.com", "/foobar.jpg"
+     *                            - alt:            strips unwanted characters. if the attribute is not set, then it gets set (to ensure valid and compatible HTML)
      *                            - numbers:  ensures that the attribute only contains numeric characters
-     *                            - { func: yourGlobalFunctionName }: calls the global function with (attr, node) as values; return non-string to remove attribute
      */
     "tags": {
-        "a": {
-            "check_attributes": {
-                "href"   : "url",
-                "rel"    : { 'func' : 'checkLinkRelation' },
-                "target" : { 'func' : 'checkLinkTarget' }
-            },
+        "tr": {
+            "add_class": {
+                "align": "align_text"
+            }
         },
-        "abbr": 1,
-        "acronym": {
-            "rename_tag": "abbr"
-        },
-        "address": {
-            "rename_tag": "p"
-        },
-        "applet": {
+        "strike": {
             "remove": 1
+        },
+        "form": {
+            "rename_tag": "div"
+        },
+        "rt": {
+            "rename_tag": "span"
+        },
+        "code": {},
+        "acronym": {
+            "rename_tag": "span"
+        },
+        "br": {
+            "add_class": {
+                "clear": "clear_br"
+            }
+        },
+        "details": {
+            "rename_tag": "div"
+        },
+        "h4": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "em": {},
+        "title": {
+            "remove": 1
+        },
+        "multicol": {
+            "rename_tag": "div"
+        },
+        "figure": {
+            "rename_tag": "div"
+        },
+        "xmp": {
+            "rename_tag": "span"
+        },
+        "small": {
+            "rename_tag": "span",
+            "set_class": "wysiwyg-font-size-smaller"
         },
         "area": {
             "remove": 1
         },
-        "article": {
-            "rename_tag": "p"
+        "time": {
+            "rename_tag": "span"
         },
-        "aside": {
-            "extract": 1
+        "dir": {
+            "rename_tag": "ul"
         },
-        "audio": {
-            "remove": 1
-        },
-        "b": 1,
-        "base": {
-            "remove": 1
-        },
-        "basefont": {
-            "remove": 1
-        },
-        "bdi": 1,
-        "bdo": 1,
-        "bgsound": {
-            "remove": 1
-        },
-        "big": {
-            "rename_tag": "strong"
-        },
-        "blink": {
-            "rename_tag": "strong"
-        },
-        "blockquote": {
-            "rename_tag": "p"
-        },
-        "body": {
-            "extract": 1
-        },
-        "br": 1,
-        "button": { "remove": 1 },
-        "canvas": {
-            "remove": 1
-        },
-        "caption": {
-            "rename_tag": "p",
-        },
-        "center": {
-            "rename_tag": "p",
-        },
-        "cite": 1,
-        "code": 1,
-        "col": {
-            "remove": 1
-        },
-        "colgroup": {
-            "remove": 1
+        "bdi": {
+            "rename_tag": "span"
         },
         "command": {
             "remove": 1
         },
-        "comment": {
-            "rename_tag": "p"
+        "ul": {},
+        "progress": {
+            "rename_tag": "span"
         },
-        "datalist": {
-            "rename_tag": "ul"
+        "dfn": {
+            "rename_tag": "span"
         },
-        "del": 1,
-        "details": {
-            "rename_tag": "p"
-        },
-        "device": {
+        "iframe": {
             "remove": 1
-        },
-        "dfn": 1,
-        "dir": {
-            "rename_tag": "ul"
-        },
-        "div": {
-            "extract" : {
-                "ifnot" : { "class" : "^(columnised|column)$" }
-            }
-        },
-        "dd": 1,
-        "dl": 1,
-        "dt": 1,
-        "em": 1,
-        "embed": {
-            "remove": 1
-        },
-        "fieldset": {
-            "extract": 1
         },
         "figcaption": {
-            "extract": 1
+            "rename_tag": "div"
         },
-        "figure": {
-            "extract": 1
-        },
-        "frameset": {
-            "remove": 1
-        },
-        "font": {
-            "extract": 1
-        },
-        "footer": {
-            "extract": 1
-        },
-        "form": {
-            "extract": 1
-        },
-        "frame": {
-            "remove": 1
-        },
-        "h1": {
-            "rename_tag": "h3"
-        },
-        "h2": {
-            "rename_tag": "h3"
-        },
-        "h3": 1,
-        "h4": 1,
-        "h5": 1,
-        "h6": 1,
-        "header": {
-            "rename_tag": "p"
-        },
-        "head": {
-            "remove": 1
-        },
-        "hgroup": {
-            "extract": 1
-        },
-        "hr": 1,
-        "html": {
-            "extract": 1
-        },
-        "i": {},
-        "iframe": {
-            "extract": 1
+        "a": {
+            "check_attributes": {
+                "href": "href"
+            },
+            "set_attributes": {
+                "rel": "nofollow",
+                "target": "_blank"
+            }
         },
         "img": {
-            "remove": 1
+            "check_attributes": {
+                "width": "numbers",
+                "alt": "alt",
+                "src": "src",
+                "height": "numbers"
+            },
+            "add_class": {
+                "align": "align_img"
+            }
         },
-        "input": { "remove": 1 },
-        "ins": 1,
-        "isindex": {
-            "remove": 1
+        "rb": {
+            "rename_tag": "span"
         },
-        "keygen": {
-            "remove": 1
-        },
-        "kbd": 1,
-        "label": {
-            "extract": 1
-        },
-        "legend": {
-            "rename_tag": "strong"
-        },
-        "li": 1,
-        "link": {
-            "remove": 1
-        },
-        "listing": {
-            "extract": 1
-        },
-        "map": {
-            "remove": 1
-        },
-        "mark": {
-            "rename_tag": "em"
-        },
-        "marquee": {
-            "rename_tag": "em"
-        },
-        "menu": {
-            "rename_tag": "ul"
-        },
-        "meta": { "remove": 1 },
-        "meter": {
-            "extract": 1
-        },
-        "multicol": {
-            "rename_tag": "div",
-            "add_class" : "columnised"
-        },
-        "nav": {
-            "rename_tag": "p"
-        },
-        "nextid": {
-            "remove": 1
-        },
-        "nobr": {
-            "rename_tag": "code"
-        },
-        "noembed": {
-            "remove": 1
+        "footer": {
+            "rename_tag": "div"
         },
         "noframes": {
             "remove": 1
         },
-        "noscript": { "remove": 1 },
+        "abbr": {
+            "rename_tag": "span"
+        },
+        "u": {},
+        "bgsound": {
+            "remove": 1
+        },
+        "sup": {
+            "rename_tag": "span"
+        },
+        "address": {
+            "rename_tag": "div"
+        },
+        "basefont": {
+            "remove": 1
+        },
+        "nav": {
+            "rename_tag": "div"
+        },
+        "h1": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "head": {
+            "remove": 1
+        },
+        "tbody": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "dd": {
+            "rename_tag": "div"
+        },
+        "s": {
+            "rename_tag": "span"
+        },
+        "li": {},
+        "td": {
+            "check_attributes": {
+                "rowspan": "numbers",
+                "colspan": "numbers"
+            },
+            "add_class": {
+                "align": "align_text"
+            }
+        },
         "object": {
             "remove": 1
         },
-        "ol": 1,
-        "optgroup": {
-            "rename_tag": "p"
-        },
-        "option": {
-            "rename_tag": "li"
-        },
-        "output": {
-            "rename_tag": "p"
-        },
-        "p": 1,
-        "param": {
-            "remove": 1
-        },
-        "plaintext": {
-            "rename_tag": "p"
-        },
-        "pre": {
-            "rename_tag": "p"
-        },
-        "progress": {
-            "remove": 1
-        },
-        "q": {
-            "check_attributes": {
-                "cite": "url"
+        "div": {
+            "add_class": {
+                "align": "align_text"
             }
         },
-        "rb": 1,
-        "rp": 1,
-        "rt": 1,
-        "ruby": 1,
-        "s": 1,
-        "samp": {
-            "rename_tag": "code"
-        },
-        "script": {
-            "remove": 1
+        "option": {
+            "rename_tag": "span"
         },
         "select": {
-            "rename_tag": "ul"
+            "rename_tag": "span"
         },
-        "section": {
-            "extract": 1
-        },
-        "small": {
-            "extract": 1,
-        },
-        "source": {
-            "remove": 1
-        },
-        "spacer": {
-            "remove": 1
-        },
-        "span": { "extract": 1 },
-        "strike": {
-            "rename_tag": "del"
-        },
-        "strong": 1,
-        "style": {
-            "remove": 1
-        },
-        "sub": 1,
-        "sup": 1,
-        "svg": { "remove": 1 },
-        "table": { "remove": 1 },
-        "tbody": { "remove": 1 },
-        "textarea": {
-            "rename_tag": "p"
-        },
-        "td": {
-            "remove": 1
-        },
-        "tfoot": {
-            "rename_tag": "p"
-        },
-        "th": {
-            "rename_tag": "strong"
-        },
-        "thead": {
-            "rename_tag": "p"
-        },
-        "time": 1,
-        "title": {
-            "remove": 1
-        },
-        "tr": {
-            "rename_tag": "p"
-        },
+        "i": {},
         "track": {
-            "remove": 1
-        },
-        "tt": {
-            "rename_tag": "blockquote"
-        },
-        "u": {
-            "extract": 1
-        },
-        "ul": 1,
-        "var": 1,
-        "video": {
             "remove": 1
         },
         "wbr": {
             "remove": 1
         },
+        "fieldset": {
+            "rename_tag": "div"
+        },
+        "big": {
+            "rename_tag": "span",
+            "set_class": "wysiwyg-font-size-larger"
+        },
+        "button": {
+            "rename_tag": "span"
+        },
+        "noscript": {
+            "remove": 1
+        },
+        "svg": {
+            "remove": 1
+        },
+        "input": {
+            "remove": 1
+        },
+        "table": {},
+        "keygen": {
+            "remove": 1
+        },
+        "h5": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "meta": {
+            "remove": 1
+        },
+        "map": {
+            "rename_tag": "div"
+        },
+        "isindex": {
+            "remove": 1
+        },
+        "mark": {
+            "rename_tag": "span"
+        },
+        "caption": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "tfoot": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "base": {
+            "remove": 1
+        },
+        "video": {
+            "remove": 1
+        },
+        "strong": {},
+        "canvas": {
+            "remove": 1
+        },
+        "output": {
+            "rename_tag": "span"
+        },
+        "marquee": {
+            "rename_tag": "span"
+        },
+        "b": {},
+        "q": {
+            "check_attributes": {
+                "cite": "url"
+            }
+        },
+        "applet": {
+            "remove": 1
+        },
+        "span": {},
+        "rp": {
+            "rename_tag": "span"
+        },
+        "spacer": {
+            "remove": 1
+        },
+        "source": {
+            "remove": 1
+        },
+        "aside": {
+            "rename_tag": "div"
+        },
+        "frame": {
+            "remove": 1
+        },
+        "section": {
+            "rename_tag": "div"
+        },
+        "body": {
+            "rename_tag": "div"
+        },
+        "ol": {},
+        "nobr": {
+            "rename_tag": "span"
+        },
+        "html": {
+            "rename_tag": "div"
+        },
+        "summary": {
+            "rename_tag": "span"
+        },
+        "var": {
+            "rename_tag": "span"
+        },
+        "del": {
+            "remove": 1
+        },
+        "blockquote": {
+            "check_attributes": {
+                "cite": "url"
+            }
+        },
+        "style": {
+            "remove": 1
+        },
+        "device": {
+            "remove": 1
+        },
+        "meter": {
+            "rename_tag": "span"
+        },
+        "h3": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "textarea": {
+            "rename_tag": "span"
+        },
+        "embed": {
+            "remove": 1
+        },
+        "hgroup": {
+            "rename_tag": "div"
+        },
+        "font": {
+            "rename_tag": "span",
+            "add_class": {
+                "size": "size_font"
+            }
+        },
+        "tt": {
+            "rename_tag": "span"
+        },
+        "noembed": {
+            "remove": 1
+        },
+        "thead": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "blink": {
+            "rename_tag": "span"
+        },
+        "plaintext": {
+            "rename_tag": "span"
+        },
         "xml": {
             "remove": 1
         },
-        "xmp": {
-            "rename_tag": "p"
+        "h6": {
+            "add_class": {
+                "align": "align_text"
+            }
         },
+        "param": {
+            "remove": 1
+        },
+        "th": {
+            "check_attributes": {
+                "rowspan": "numbers",
+                "colspan": "numbers"
+            },
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "legend": {
+            "rename_tag": "span"
+        },
+        "hr": {},
+        "label": {
+            "rename_tag": "span"
+        },
+        "dl": {
+            "rename_tag": "div"
+        },
+        "kbd": {
+            "rename_tag": "span"
+        },
+        "listing": {
+            "rename_tag": "div"
+        },
+        "dt": {
+            "rename_tag": "span"
+        },
+        "nextid": {
+            "remove": 1
+        },
+        "pre": {},
+        "center": {
+            "rename_tag": "div",
+            "set_class": "wysiwyg-text-align-center"
+        },
+        "audio": {
+            "remove": 1
+        },
+        "datalist": {
+            "rename_tag": "span"
+        },
+        "samp": {
+            "rename_tag": "span"
+        },
+        "col": {
+            "remove": 1
+        },
+        "article": {
+            "rename_tag": "div"
+        },
+        "cite": {},
+        "link": {
+            "remove": 1
+        },
+        "script": {
+            "remove": 1
+        },
+        "bdo": {
+            "rename_tag": "span"
+        },
+        "menu": {
+            "rename_tag": "ul"
+        },
+        "colgroup": {
+            "remove": 1
+        },
+        "ruby": {
+            "rename_tag": "span"
+        },
+        "h2": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "ins": {
+            "rename_tag": "span"
+        },
+        "p": {
+            "add_class": {
+                "align": "align_text"
+            }
+        },
+        "sub": {
+            "rename_tag": "span"
+        },
+        "comment": {
+            "remove": 1
+        },
+        "frameset": {
+            "remove": 1
+        },
+        "optgroup": {
+            "rename_tag": "span"
+        },
+        "header": {
+            "rename_tag": "div"
+        }
     }
 };

--- a/parser_rules/advanced.js
+++ b/parser_rules/advanced.js
@@ -102,452 +102,336 @@ var wysihtml5ParserRules = {
      *                            - numbers:  ensures that the attribute only contains numeric characters
      */
     "tags": {
-        "tr": {
-            "add_class": {
-                "align": "align_text"
-            }
+        "a": {
+            "check_attributes": {
+                "href"   : "href",
+                "rel"    : { 'func' : 'checkLinkRelation' },
+                "target" : { 'func' : 'checkLinkTarget' }
+            },
         },
-        "strike": {
-            "remove": 1
-        },
-        "form": {
-            "rename_tag": "div"
-        },
-        "rt": {
-            "rename_tag": "span"
-        },
-        "code": {},
+        "abbr": 1,
         "acronym": {
-            "rename_tag": "span"
+            "rename_tag": "abbr"
         },
-        "br": {
-            "add_class": {
-                "clear": "clear_br"
-            }
+        "address": {
+            "rename_tag": "p"
         },
-        "details": {
-            "rename_tag": "div"
-        },
-        "h4": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "em": {},
-        "title": {
+        "applet": {
             "remove": 1
-        },
-        "multicol": {
-            "rename_tag": "div"
-        },
-        "figure": {
-            "rename_tag": "div"
-        },
-        "xmp": {
-            "rename_tag": "span"
-        },
-        "small": {
-            "rename_tag": "span",
-            "set_class": "wysiwyg-font-size-smaller"
         },
         "area": {
             "remove": 1
         },
-        "time": {
-            "rename_tag": "span"
+        "article": {
+            "rename_tag": "p"
         },
-        "dir": {
-            "rename_tag": "ul"
+        "aside": {
+            "extract": 1
         },
-        "bdi": {
-            "rename_tag": "span"
-        },
-        "command": {
+        "audio": {
             "remove": 1
         },
-        "ul": {},
-        "progress": {
-            "rename_tag": "span"
-        },
-        "dfn": {
-            "rename_tag": "span"
-        },
-        "iframe": {
+        "b": 1,
+        "base": {
             "remove": 1
-        },
-        "figcaption": {
-            "rename_tag": "div"
-        },
-        "a": {
-            "check_attributes": {
-                "href": "href"
-            },
-            "set_attributes": {
-                "rel": "nofollow",
-                "target": "_blank"
-            }
-        },
-        "img": {
-            "check_attributes": {
-                "width": "numbers",
-                "alt": "alt",
-                "src": "src",
-                "height": "numbers"
-            },
-            "add_class": {
-                "align": "align_img"
-            }
-        },
-        "rb": {
-            "rename_tag": "span"
-        },
-        "footer": {
-            "rename_tag": "div"
-        },
-        "noframes": {
-            "remove": 1
-        },
-        "abbr": {
-            "rename_tag": "span"
-        },
-        "u": {},
-        "bgsound": {
-            "remove": 1
-        },
-        "sup": {
-            "rename_tag": "span"
-        },
-        "address": {
-            "rename_tag": "div"
         },
         "basefont": {
             "remove": 1
         },
-        "nav": {
-            "rename_tag": "div"
+        "bdi": 1,
+        "bdo": 1,
+        "bgsound": {
+            "remove": 1
+        },
+        "big": {
+            "rename_tag": "strong"
+        },
+        "blink": {
+            "rename_tag": "strong"
+        },
+        "blockquote": {
+            "rename_tag": "p"
+        },
+        "body": {
+            "extract": 1
+        },
+        "br": 1,
+        "button": { "remove": 1 },
+        "canvas": {
+            "remove": 1
+        },
+        "caption": {
+            "rename_tag": "p",
+        },
+        "center": {
+            "rename_tag": "p",
+        },
+        "cite": 1,
+        "code": 1,
+        "col": {
+            "remove": 1
+        },
+        "colgroup": {
+            "remove": 1
+        },
+        "command": {
+            "remove": 1
+        },
+        "comment": {
+            "rename_tag": "p"
+        },
+        "datalist": {
+            "rename_tag": "ul"
+        },
+        "del": 1,
+        "details": {
+            "rename_tag": "p"
+        },
+        "device": {
+            "remove": 1
+        },
+        "dfn": 1,
+        "dir": {
+            "rename_tag": "ul"
+        },
+        "div": {
+            "extract" : {
+                "ifnot" : { "class" : "^(columnised|column)$" }
+            }
+        },
+        "dd": 1,
+        "dl": 1,
+        "dt": 1,
+        "em": 1,
+        "embed": {
+            "remove": 1
+        },
+        "fieldset": {
+            "extract": 1
+        },
+        "figcaption": {
+            "extract": 1
+        },
+        "figure": {
+            "extract": 1
+        },
+        "frameset": {
+            "remove": 1
+        },
+        "font": {
+            "extract": 1
+        },
+        "footer": {
+            "extract": 1
+        },
+        "form": {
+            "extract": 1
+        },
+        "frame": {
+            "remove": 1
         },
         "h1": {
-            "add_class": {
-                "align": "align_text"
-            }
+            "rename_tag": "h3"
+        },
+        "h2": {
+            "rename_tag": "h3"
+        },
+        "h3": 1,
+        "h4": 1,
+        "h5": 1,
+        "h6": 1,
+        "header": {
+            "rename_tag": "p"
         },
         "head": {
             "remove": 1
         },
-        "tbody": {
-            "add_class": {
-                "align": "align_text"
-            }
+        "hgroup": {
+            "extract": 1
         },
-        "dd": {
-            "rename_tag": "div"
+        "hr": 1,
+        "html": {
+            "extract": 1
         },
-        "s": {
-            "rename_tag": "span"
+        "i": 1,
+        "iframe": {
+            "extract": 1
         },
-        "li": {},
-        "td": {
-            "check_attributes": {
-                "rowspan": "numbers",
-                "colspan": "numbers"
-            },
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "object": {
+        "img": {
             "remove": 1
         },
-        "div": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "option": {
-            "rename_tag": "span"
-        },
-        "select": {
-            "rename_tag": "span"
-        },
-        "i": {},
-        "track": {
-            "remove": 1
-        },
-        "wbr": {
-            "remove": 1
-        },
-        "fieldset": {
-            "rename_tag": "div"
-        },
-        "big": {
-            "rename_tag": "span",
-            "set_class": "wysiwyg-font-size-larger"
-        },
-        "button": {
-            "rename_tag": "span"
-        },
-        "noscript": {
-            "remove": 1
-        },
-        "svg": {
-            "remove": 1
-        },
-        "input": {
-            "remove": 1
-        },
-        "table": {},
-        "keygen": {
-            "remove": 1
-        },
-        "h5": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "meta": {
-            "remove": 1
-        },
-        "map": {
-            "rename_tag": "div"
-        },
+        "input": { "remove": 1 },
+        "ins": 1,
         "isindex": {
             "remove": 1
         },
+        "keygen": {
+            "remove": 1
+        },
+        "kbd": 1,
+        "label": {
+            "extract": 1
+        },
+        "legend": {
+            "rename_tag": "strong"
+        },
+        "li": 1,
+        "link": {
+            "remove": 1
+        },
+        "listing": {
+            "extract": 1
+        },
+        "map": {
+            "remove": 1
+        },
         "mark": {
-            "rename_tag": "span"
-        },
-        "caption": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "tfoot": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "base": {
-            "remove": 1
-        },
-        "video": {
-            "remove": 1
-        },
-        "strong": {},
-        "canvas": {
-            "remove": 1
-        },
-        "output": {
-            "rename_tag": "span"
+            "rename_tag": "em"
         },
         "marquee": {
-            "rename_tag": "span"
+            "rename_tag": "em"
         },
-        "b": {},
+        "menu": {
+            "rename_tag": "ul"
+        },
+        "meta": { "remove": 1 },
+        "meter": {
+            "extract": 1
+        },
+        "multicol": {
+            "rename_tag": "div",
+            "add_class" : "columnised"
+        },
+        "nav": {
+            "rename_tag": "p"
+        },
+        "nextid": {
+            "remove": 1
+        },
+        "nobr": {
+            "rename_tag": "code"
+        },
+        "noembed": {
+            "remove": 1
+        },
+        "noframes": {
+            "remove": 1
+        },
+        "noscript": { "remove": 1 },
+        "object": {
+            "remove": 1
+        },
+        "ol": 1,
+        "optgroup": {
+            "rename_tag": "p"
+        },
+        "option": {
+            "rename_tag": "li"
+        },
+        "output": {
+            "rename_tag": "p"
+        },
+        "p": 1,
+        "param": {
+            "remove": 1
+        },
+        "plaintext": {
+            "rename_tag": "p"
+        },
+        "pre": {
+            "rename_tag": "p"
+        },
+        "progress": {
+            "remove": 1
+        },
         "q": {
             "check_attributes": {
                 "cite": "url"
             }
         },
-        "applet": {
-            "remove": 1
-        },
-        "span": {},
-        "rp": {
-            "rename_tag": "span"
-        },
-        "spacer": {
-            "remove": 1
-        },
-        "source": {
-            "remove": 1
-        },
-        "aside": {
-            "rename_tag": "div"
-        },
-        "frame": {
-            "remove": 1
-        },
-        "section": {
-            "rename_tag": "div"
-        },
-        "body": {
-            "rename_tag": "div"
-        },
-        "ol": {},
-        "nobr": {
-            "rename_tag": "span"
-        },
-        "html": {
-            "rename_tag": "div"
-        },
-        "summary": {
-            "rename_tag": "span"
-        },
-        "var": {
-            "rename_tag": "span"
-        },
-        "del": {
-            "remove": 1
-        },
-        "blockquote": {
-            "check_attributes": {
-                "cite": "url"
-            }
-        },
-        "style": {
-            "remove": 1
-        },
-        "device": {
-            "remove": 1
-        },
-        "meter": {
-            "rename_tag": "span"
-        },
-        "h3": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "textarea": {
-            "rename_tag": "span"
-        },
-        "embed": {
-            "remove": 1
-        },
-        "hgroup": {
-            "rename_tag": "div"
-        },
-        "font": {
-            "rename_tag": "span",
-            "add_class": {
-                "size": "size_font"
-            }
-        },
-        "tt": {
-            "rename_tag": "span"
-        },
-        "noembed": {
-            "remove": 1
-        },
-        "thead": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "blink": {
-            "rename_tag": "span"
-        },
-        "plaintext": {
-            "rename_tag": "span"
-        },
-        "xml": {
-            "remove": 1
-        },
-        "h6": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "param": {
-            "remove": 1
-        },
-        "th": {
-            "check_attributes": {
-                "rowspan": "numbers",
-                "colspan": "numbers"
-            },
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "legend": {
-            "rename_tag": "span"
-        },
-        "hr": {},
-        "label": {
-            "rename_tag": "span"
-        },
-        "dl": {
-            "rename_tag": "div"
-        },
-        "kbd": {
-            "rename_tag": "span"
-        },
-        "listing": {
-            "rename_tag": "div"
-        },
-        "dt": {
-            "rename_tag": "span"
-        },
-        "nextid": {
-            "remove": 1
-        },
-        "pre": {},
-        "center": {
-            "rename_tag": "div",
-            "set_class": "wysiwyg-text-align-center"
-        },
-        "audio": {
-            "remove": 1
-        },
-        "datalist": {
-            "rename_tag": "span"
-        },
+        "rb": 1,
+        "rp": 1,
+        "rt": 1,
+        "ruby": 1,
+        "s": 1,
         "samp": {
-            "rename_tag": "span"
-        },
-        "col": {
-            "remove": 1
-        },
-        "article": {
-            "rename_tag": "div"
-        },
-        "cite": {},
-        "link": {
-            "remove": 1
+            "rename_tag": "code"
         },
         "script": {
             "remove": 1
         },
-        "bdo": {
-            "rename_tag": "span"
-        },
-        "menu": {
+        "select": {
             "rename_tag": "ul"
         },
-        "colgroup": {
+        "section": {
+            "extract": 1
+        },
+        "small": {
+            "extract": 1,
+        },
+        "source": {
             "remove": 1
         },
-        "ruby": {
-            "rename_tag": "span"
-        },
-        "h2": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "ins": {
-            "rename_tag": "span"
-        },
-        "p": {
-            "add_class": {
-                "align": "align_text"
-            }
-        },
-        "sub": {
-            "rename_tag": "span"
-        },
-        "comment": {
+        "spacer": {
             "remove": 1
         },
-        "frameset": {
+        "span": { "extract": 1 },
+        "strike": {
+            "rename_tag": "del"
+        },
+        "strong": 1,
+        "style": {
             "remove": 1
         },
-        "optgroup": {
-            "rename_tag": "span"
+        "sub": 1,
+        "sup": 1,
+        "svg": { "remove": 1 },
+        "table": { "remove": 1 },
+        "tbody": { "remove": 1 },
+        "textarea": {
+            "rename_tag": "p"
         },
-        "header": {
-            "rename_tag": "div"
-        }
+        "td": {
+            "remove": 1
+        },
+        "tfoot": {
+            "rename_tag": "p"
+        },
+        "th": {
+            "rename_tag": "strong"
+        },
+        "thead": {
+            "rename_tag": "p"
+        },
+        "time": 1,
+        "title": {
+            "remove": 1
+        },
+        "tr": {
+            "rename_tag": "p"
+        },
+        "track": {
+            "remove": 1
+        },
+        "tt": {
+            "rename_tag": "blockquote"
+        },
+        "u": {
+            "extract": 1
+        },
+        "ul": 1,
+        "var": 1,
+        "video": {
+            "remove": 1
+        },
+        "wbr": {
+            "remove": 1
+        },
+        "xml": {
+            "remove": 1
+        },
+        "xmp": {
+            "rename_tag": "p"
+        },
     }
 };

--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -184,23 +184,85 @@ wysihtml5.dom.parse = (function() {
     
     if (nodeName in tagRules) {
       rule = tagRules[nodeName];
-      if (!rule || rule.remove) {
-        return null;
+      method = _checkRules(oldNode, rule);
+      switch (method) {
+        case 'remove' :
+              return null;
+              break;
+        case 'extract':
+              newNode = oldNode.ownerDocument.createDocumentFragment();
+              break;
+        case 'rename_tag':
+              rule = typeof(rule) === "string" ? { rename_tag: rule } : rule;
+              newNode = oldNode.ownerDocument.createElement(rule.rename_tag || nodeName);
+              break;
+        case 'keep':
+              newNode = oldNode.ownerDocument.createElement(nodeName);
+              break;
       }
-      
-      rule = typeof(rule) === "string" ? { rename_tag: rule } : rule;
     } else if (oldNode.firstChild) {
       rule = { rename_tag: DEFAULT_NODE_NAME };
+      newNode = oldNode.ownerDocument.createElement(DEFAULT_NODE_NAME);
     } else {
       // Remove empty unknown elements
       return null;
     }
     
-    newNode = oldNode.ownerDocument.createElement(rule.rename_tag || nodeName);
     _handleAttributes(oldNode, newNode, rule);
     
     oldNode = null;
     return newNode;
+  }
+  /* function _checkRules(node, rules)
+   *
+   * returns the name of the rule which should be applied to the node
+   *
+   * @param node object - the node to check
+   * @param rules mixed - a string or object containing the rules for the node's tag
+   * @return string - name of the rule to apply
+   */
+  function _checkRules (node, rules) {
+    if (!rules) { return 'remove'; }
+    if (typeof(rules) == 'string') { return 'rename_tag'; }
+    
+    var finalRules = [];
+    var priorityOfRules = ['remove', 'extract', 'rename_tag', 'keep'];
+    for(var rule in rules) {
+        if (typeof(rules[rule]) != 'object') { finalRules.push(rule); continue; }
+        var add = true;
+        if (rules[rule].if && !_checkAttributesRules(node, rules[rule].if)) {
+            add = false;
+        }
+        if (add && rules[rule].ifnot && _checkAttributesRules(node, rules[rule].ifnot)) {
+            add = false;
+        }
+        if (add) { finalRules.push(rule); }
+    }
+    var ruleIndex = priorityOfRules.length-1;
+    for (var i = 0; i < finalRules.length; i++) {
+        var ind = priorityOfRules.indexOf(finalRules[i]);
+        if (ind > -1 && ind < ruleIndex) { ruleIndex = ind; }
+    }
+    return priorityOfRules[ruleIndex];
+  }
+
+  /* function _checkAttributesRules (node, setup)
+   *
+   * function checks all attributes set in setup with the corresponding patterns
+   *
+   * @param node object - the node to check
+   * @param setup object - a object where propertyName = node attribute and propertyValue = check pattern
+   * return boolean - whether the node's attributes comply to all patterns or not
+   */
+  function _checkAttributesRules (node, setup) {
+    for (var attrName in setup) {
+        var attr = _getAttribute(node, attrName);
+        var patt = new RegExp(setup[attrName], 'i');
+        if (typeof(attr) === 'undefined' || attr == null || !attr.match(patt)) {
+            return false;
+        }
+    }
+    return true;
   }
   
   function _handleAttributes(oldNode, newNode, rule) {
@@ -229,11 +291,16 @@ wysihtml5.dom.parse = (function() {
     
     if (checkAttributes) {
       for (attributeName in checkAttributes) {
-        method = attributeCheckMethods[checkAttributes[attributeName]];
+        if (typeof(checkAttributes[attributeName]) === 'string') {
+            method = attributeCheckMethods[checkAttributes[attributeName]];
+        }
+        if (typeof(checkAttributes[attributeName]) === 'object' && typeof(checkAttributes[attributeName].func) !== 'undefined') {
+            method = window[checkAttributes[attributeName].func];
+        }
         if (!method) {
           continue;
         }
-        newAttributeValue = method(_getAttribute(oldNode, attributeName));
+        newAttributeValue = method(_getAttribute(oldNode, attributeName), oldNode);
         if (typeof(newAttributeValue) === "string") {
           attributes[attributeName] = newAttributeValue;
         }

--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -48,42 +48,6 @@
  *      }
  *    });
  *    // => '<p class="red">foo</p><p>bar</p>'
- *
- *    var userHTML = '<div class="red">foo</div><div class="pink">bar</div>';
- *    wysihtml5.dom.parse(userHTML, {
- *      tags: {
- *        div: {
- *          extract: 1
- *        }
- *      }
- *    });
- *    // => 'foobar'
- *
- *    var userHTML = '<div class="red">foo</div><div class="pink">bar</div>';
- *    wysihtml5.dom.parse(userHTML, {
- *      tags: {
- *        div: {
- *          extract: {
- *             if : { class: "^red|other$" }
- *             ifnot : { class: "^pink$" }
- *          }
- *        }
- *      }
- *    });
- *
- *    // => 'foo<div class="pink">bar</div>'
- *    function myCheck (attr, node) { if (attr == 'localhost') { return '#'; } return attr; }
- *    var userHTML = '<a href="http://google.com">foo</a><a href="localhost">bar</a>';
- *    wysihtml5.dom.parse(userHTML, {
- *      tags: {
- *        a: {
- *          check_attributes: { 
- *            href: { func: 'myCheck' }
- *          }
- *        }
- *      }
- *    });
- *    // => '<a href="http://google.com">foo</a><a href="#">bar</a>'
  */
 wysihtml5.dom.parse = (function() {
   
@@ -220,88 +184,25 @@ wysihtml5.dom.parse = (function() {
     
     if (nodeName in tagRules) {
       rule = tagRules[nodeName];
-      method = _checkRules(oldNode, rule);
-      switch (method) {
-        case 'remove' :
-              return null;
-              break;
-        case 'extract':
-              newNode = oldNode.ownerDocument.createDocumentFragment();
-              break;
-        case 'rename_tag':
-              rule = typeof(rule) === "string" ? { rename_tag: rule } : rule;
-              newNode = oldNode.ownerDocument.createElement(rule.rename_tag || nodeName);
-              break;
-        case 'keep':
-              newNode = oldNode.ownerDocument.createElement(nodeName);
-              break;
+      if (!rule || rule.remove) {
+        return null;
       }
+      
+      rule = typeof(rule) === "string" ? { rename_tag: rule } : rule;
     } else if (oldNode.firstChild) {
       rule = { rename_tag: DEFAULT_NODE_NAME };
-      newNode = oldNode.ownerDocument.createElement(DEFAULT_NODE_NAME);
     } else {
       // Remove empty unknown elements
       return null;
     }
     
+    newNode = oldNode.ownerDocument.createElement(rule.rename_tag || nodeName);
     _handleAttributes(oldNode, newNode, rule);
     
     oldNode = null;
     return newNode;
   }
   
-  /* function _checkRules(node, rules)
-   *
-   * returns the name of the rule which should be applied to the node
-   *
-   * @param node object - the node to check
-   * @param rules mixed - a string or object containing the rules for the node's tag
-   * @return string - name of the rule to apply
-   */
-  function _checkRules (node, rules) {
-    if (typeof(rules) == 'undefined' || !rules) { return 'remove'; }
-    if (typeof(rules) == 'string') { return 'rename_tag'; }
-    
-    var finalRules = [];
-    var priorityOfRules = ['remove', 'extract', 'rename_tag', 'keep'];
-    for(var rule in rules) {
-        if (typeof(rules[rule]) != 'object') { finalRules.push(rule); continue; }
-        var add = true;
-        if (rules[rule].if && !_checkAttributesRules(node, rules[rule].if)) {
-            add = false;
-        }
-        if (add && rules[rule].ifnot && _checkAttributesRules(node, rules[rule].ifnot)) {
-            add = false;
-        }
-        if (add) { finalRules.push(rule); }
-    }
-    var ruleIndex = priorityOfRules.length-1;
-    for (var i = 0; i < finalRules.length; i++) {
-        var ind = priorityOfRules.indexOf(finalRules[i]);
-        if (ind > -1 && ind < ruleIndex) { ruleIndex = ind; }
-    }
-    return priorityOfRules[ruleIndex];
-  }
-
-  /* function _checkAttributesRules (node, setup)
-   *
-   * function checks all attributes set in setup with the corresponding patterns
-   *
-   * @param node object - the node to check
-   * @param setup object - a object where propertyName = node attribute and propertyValue = check pattern
-   * return boolean - whether the node's attributes comply to all patterns or not
-   */
-  function _checkAttributesRules (node, setup) {
-    for (var attrName in setup) {
-        var attr = _getAttribute(node, attrName);
-        var patt = new RegExp(setup[attrName], 'i');
-        if (typeof(attr) === 'undefined' || attr == null || !attr.match(patt)) {
-            return false;
-        }
-    }
-    return true;
-  }
-
   function _handleAttributes(oldNode, newNode, rule) {
     var attributes          = {},                         // fresh new set of attributes to set on newNode
         setClass            = rule.set_class,             // classes to set
@@ -328,16 +229,11 @@ wysihtml5.dom.parse = (function() {
     
     if (checkAttributes) {
       for (attributeName in checkAttributes) {
-        if (typeof(checkAttributes[attributeName]) === 'string') {
-            method = attributeCheckMethods[checkAttributes[attributeName]];
-        }
-        if (typeof(checkAttributes[attributeName]) === 'object' && typeof(checkAttributes[attributeName].func) !== 'undefined') {
-            method = window[checkAttributes[attributeName].func];
-        }
+        method = attributeCheckMethods[checkAttributes[attributeName]];
         if (!method) {
           continue;
         }
-        newAttributeValue = method(_getAttribute(oldNode, attributeName), oldNode);
+        newAttributeValue = method(_getAttribute(oldNode, attributeName));
         if (typeof(newAttributeValue) === "string") {
           attributes[attributeName] = newAttributeValue;
         }


### PR DESCRIPTION
Added support for "extract" tag parser option:

consider following case:

```
<div><p>some text</p></div>
```

parser rule

```
"div": "extract"
```

gives you

```
<p>some text</p>
```

Added support for conditions on parser options:

```
<div class="dontlike"><p>text A</p><div class="like">text B</div></div>
```

parser rule

```
"div": {
  "extract": {
    "if": {
      "class": "^dontlike$"
    }
  }
}
```

result:

```
<p>text A</p><div class="like">text B</div>
```

and finally callbacks for attribute checking:

```
"a": {
  "check_attributes": {
    "rel": { "func": "checkLinkRelation" }
  }
}
```

```
function checkLinkRelation(attr, node) {
  var l = node.getAttribute('href');
  var p = new RegExp('^((ht|f)tps?:\/\/)');
  if (l.match(p)) { return 'nofollow'; }
  return false;
}
```

So if <a href="/my/local/path">link text</a> gets pasted or link set, then no rel-attribute is set.
On the other hand inserting <a href="http://google.com">to Goggles</a> results in: rel="nofollow"

Oh, yes - and for convenience reasons, i sorted the advanced tag roles...
