### PR TITLE
IE8 'unknown runtime error' when setting 'invalid' html

### DIFF
--- a/src/views/composer.js
+++ b/src/views/composer.js
@@ -38,7 +38,13 @@
       if (parse) {
         html = this.parent.parse(html);
       }
-      this.element.innerHTML = html;
+      
+      try {
+        this.element.innerHTML = html;
+      }
+      catch (e) {
+        this.element.innerText = html;
+      }
     },
 
     show: function() {


### PR DESCRIPTION
Ran into a weird error in IE8 where it doesnt throws "unknown runtime error" when you try to set the innerHTML and pass it _what it thinks_ is invalid HTML.  I stumbled across some information when searching if this was a known error: https://www.google.com/search?sugexp=chrome,mod=0&sourceid=chrome&ie=UTF-8&q=unknown+runtime+error+wysihtml5+ie8&qscrl=1

In the end, what I was using seemed to be perfectly valid HTML (all tags were closed and nested properly) but I  think maybe it didnt like the wysiwyg-\* classes.  Anyway, I started playing around and this solution actually worked for me in IE8 and still works great in all other normal browsers.  I catch the exception and then set the innerText to the html value.  The iframe kinda flashes for a second, but then it all gets parsed correctly and displayed correctly as well.

So, for what its worth (not thoroughly tested) I hope this is helpful.

Thanks for the awesome library!

Jorin
