### PR TITLE
Proxy key* events

### DIFF
--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -67,6 +67,11 @@
       }, 0);
     });
 
+    // --------- Proxy events ---------
+    dom.observe(element, ["keyup", "keydown", "keypress"], function(event) {
+        that.parent.fire(event.type, event).fire(event.type + ":composer", event);
+    });
+
     // --------- neword event ---------
     dom.observe(element, "keyup", function(event) {
       var keyCode = event.keyCode;

--- a/src/views/textarea.js
+++ b/src/views/textarea.js
@@ -50,7 +50,7 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
          * Calling focus() or blur() on an element doesn't synchronously trigger the attached focus/blur events
          * This is the case for focusin and focusout, so let's use them whenever possible, kkthxbai
          */
-        events = wysihtml5.browser.supportsEvent("focusin") ? ["focusin", "focusout", "change"] : ["focus", "blur", "change"];
+        events = wysihtml5.browser.supportsEvent("focusin") ? ["focusin", "focusout", "change", "keyup", "keydown", "keypress"] : ["focus", "blur", "change", "keyup", "keydown", "keypress"];
     
     parent.on("beforeload", function() {
       wysihtml5.dom.observe(element, events, function(event) {


### PR DESCRIPTION
Forward the keyup, keydown, and keypress events from both the textarea and composer. This doesn't have a noticeable performance impact even when mashing the keyboard and is very convenient.
