### PR TITLE
Exposing events from the editor

### DIFF
--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -110,6 +110,10 @@
         }
       });
     }
+
+    dom.observe(element, "click", function(event) {
+      that.parent.fire("element:clicked", event);
+    });
     
     if (browser.hasHistoryIssue() && browser.supportsSelectionModify()) {
       dom.observe(element, "keydown", function(event) {


### PR DESCRIPTION
How best to do this? 

Attached is @jhollingworth's attempt at getting what I want, is this best? (It doesn't seem like it would scale).

What I want to be able to do is manipulate an image, which means I need to know when one has been selected, which means I need to be listening to events from inside the editor.

This is tangentially linked to my end-goal of adding pasting behaviour for images to wysihtml5 (My client put that work on hold in preference to other features)
