### PR TITLE
Option to disable welcome message in console.log

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -55,7 +55,9 @@
     // Placeholder text to use, defaults to the placeholder attribute on the textarea element
     placeholderText:      undef,
     // Whether the rich text editor should be rendered on touch devices (wysihtml5 >= 0.3.0 comes with basic support for iOS 5)
-    supportTouchDevices:  true
+    supportTouchDevices:  true,
+    // Display a welcome message in the console
+    consoleWelcomeMessage: true
   };
   
   wysihtml5.Editor = wysihtml5.lang.Dispatcher.extend(
@@ -91,9 +93,11 @@
         }
       });
       
-      try {
-        console.log("Heya! This page is using wysihtml5 for rich text editing. Check out https://github.com/xing/wysihtml5");
-      } catch(e) {}
+      if (this.config.consoleWelcomeMessage) {
+	try {
+          console.log("Heya! This page is using wysihtml5 for rich text editing. Check out https://github.com/xing/wysihtml5");
+	} catch(e) {}
+      }
     },
     
     isCompatible: function() {


### PR DESCRIPTION
I'm personally rather fond of the console.log welcome message, but we've got a client that finds it unprofessional.  This keeps it on by default, and allows the user to turn it off by passing in consoleWelcomeMessage: true
