### PR TITLE
Add an hide event for the ToolbarDialog and add custom action to the toolbar without firing the editor blur event.

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -48,6 +48,13 @@ wysihtml5.Commands = Base.extend(
         result = this.doc.execCommand(command, false, value);
       } catch(e) {}
     }
+
+	/*custom dialog action for the toolbar part #1
+	if you want to add some custom dialog actions, the "unobserve blur" is not fired.
+	use " data-wysihtml5-command="" " if you want to add custom dialog actions to the toolbar */
+	if (command === ""){		  
+		this.editor.fire("custom:command");
+	}
     
     this.editor.fire("aftercommand:composer");
     return result;

--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -85,6 +85,12 @@
           that.editor.fire("show:dialog", { command: command, dialogContainer: dialogElement, commandLink: link });
         });
 
+        dialog.on("hide", function() {
+          caretBookmark = that.composer.selection.getBookmark();
+
+          that.editor.fire("hide:dialog", { command: command, dialogContainer: dialogElement, commandLink: link });
+        });
+
         dialog.on("save", function(attributes) {
           if (caretBookmark) {
             that.composer.selection.setBookmark(caretBookmark);

--- a/src/undo_manager.js
+++ b/src/undo_manager.js
@@ -127,7 +127,16 @@
         
         .on("beforecommand:composer", function() {
           that.transact();
+        })
+
+		/*custom dialog action for the toolbar part #2
+		if you want to add some custom dialog actions, the "unobserve blur" is not fired.
+		use " data-wysihtml5-command="" " if you want to add custom dialog actions to the toolbar */
+		
+		.on("custom:command", function() {
+          that.transact();
         });
+		
     },
     
     transact: function() {


### PR DESCRIPTION
I added an hide event for the ToolbarDialog and i wanted to add other custom dialog actions to the toolbar.

The problem is that :
data-wysihtml5-dialog-action="cancel"
data-wysihtml5-dialog-action="save" etc … unobserve the blur event to
(wisely) not fire the editor blur event when the mouse click on those
'buttons'/actions

if you want to add some custom dialog actions, the "unobserve blur" is
not fired. So it fires a blur event form the text editor and (in my
case) close the toolbar dialog.
so i added a custom:command event for custom dialog action like this:

data-wysihtml5-command=""

You can now add custom action to the toolbar without firing the editor
blur event.
