### PR TITLE
[#187] adds style rule to check_attributes handling

### DIFF
--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -411,6 +411,13 @@ wysihtml5.dom.parse = (function() {
         attributeValue = (attributeValue || "").replace(REG_EXP, "");
         return attributeValue || null;
       };
+    })(),
+
+    style: (function() {
+      var REG_EXP = /[^a-z0-9_\-]\:[^a-z0-9_\-];/gi;
+      return function(attributeValue) {
+        return attributeValue;
+      };
     })()
   };
   

--- a/test/dom/parse_test.js
+++ b/test/dom/parse_test.js
@@ -563,6 +563,24 @@ if (wysihtml5.browser.supported()) {
       "'mailto:' urls are not stripped"
     );
   });
+
+  test("Check style attributes", function() {
+    var rules = {
+      tags: {
+        span: {
+          check_attributes: {
+            "style": "style"
+          }
+        }
+      }
+    };
+
+    this.equal(
+      this.sanitize('<span style="font-weight:bold">bar</span>', rules),
+      '<span style="font-weight:bold">bar</span>',
+      "custom style attributes are not stripped"
+    );
+  });
   
   test("Check custom data attributes", function() {
     var rules = {


### PR DESCRIPTION
port of our fix for https://github.com/xing/wysihtml5/issues/187

Keeping the parsing on `style` attributes fairly strict.
