### PR TITLE
[BUGFIX] Image Class Attribute & Non-Anchor Elements "href" Attribute

### DIFF
--- a/src/commands/insertImage.js
+++ b/src/commands/insertImage.js
@@ -18,7 +18,6 @@
       var doc     = composer.doc,
           image   = this.state(composer),
           textNode,
-          i,
           parent;
 
       if (image) {
@@ -41,11 +40,8 @@
 
       image = doc.createElement(NODE_NAME);
       
-      for (i in value) {
-        if (i === "className") {
-          i = "class";
-        }
-        image.setAttribute(i, value[i]);
+      for (var i in value) {
+        image.setAttribute(i === "className" ? "class" : i, value[i]);
       }
 
       composer.selection.insertNode(image);

--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -153,10 +153,14 @@
       for (; i<length; i++) {
         // 'javascript:;' and unselectable=on Needed for IE, but done in all browsers to make sure that all get the same css applied
         // (you know, a:link { ... } doesn't match anchors with missing href attribute)
-        dom.setAttributes({
-          href:         "javascript:;",
-          unselectable: "on"
-        }).on(links[i]);
+        if (links[i].tagName === "A") {
+          dom.setAttributes({
+            href:         "javascript:;",
+            unselectable: "on"
+          }).on(links[i]);
+        } else {
+          dom.setAttributes({ unselectable: "on" }).on(links[i]);
+        }
       }
 
       // Needed for opera and chrome


### PR DESCRIPTION
1) Bugfix to ensure that the "class" attribute is properly saved when inserting an image for the first time.
2) Bugfix to prevent non-anchor elements in the toolbar from having the "href" attribute set.
