### PR TITLE
Dialog Get Attribute Bugfix

### DIFF
--- a/src/toolbar/dialog.js
+++ b/src/toolbar/dialog.js
@@ -154,7 +154,7 @@
         }
         
         fieldName = field.getAttribute(ATTRIBUTE_FIELDS);
-        newValue  = this.elementToChange ? (this.elementToChange[fieldName] || "") : field.defaultValue;
+        newValue  = this.elementToChange ? (this.elementToChange.getAttribute(fieldName) || "") : field.defaultValue;
         field.value = newValue;
       }
     },


### PR DESCRIPTION
Bugfix to ensure that when interpolating fields into the dialog that we pull the actual attributes from the element instead of using the shorthand dot-tag notation. The reason for this is that the shorthand
notation may potentially store a different value (e.g. Consider the following attributes: "href", "disabled", "checked"). Proper method for retrieving the attribute is to use the native DOM "getAttribute" method.
