### PR TITLE
Added html config option to specify HTML markup in sandboxed iframe

### DIFF
--- a/src/dom/sandbox.js
+++ b/src/dom/sandbox.js
@@ -153,10 +153,10 @@
           iframeWindow   = iframe.contentWindow,
           iframeDocument = iframe.contentWindow.document,
           charset        = doc.characterSet || doc.charset || "utf-8",
-          sandboxHtml    = this._getHtml({
-            charset:      charset,
-            stylesheets:  this.config.stylesheets
-          });
+          sandboxHtml    = this.config.html || this._getHtml({
+                                                              charset:      charset,
+                                                              stylesheets:  this.config.stylesheets
+                                                            });
 
       // Create the basic dom tree including proper DOCTYPE and charset
       iframeDocument.open("text/html", "replace");

--- a/src/views/composer.js
+++ b/src/views/composer.js
@@ -112,7 +112,8 @@
       this.sandbox = new dom.Sandbox(function() {
         that._create();
       }, {
-        stylesheets:  this.config.stylesheets
+        stylesheets:  this.config.stylesheets,
+        html:         this.config.html
       });
       this.iframe  = this.sandbox.getIframe();
       


### PR DESCRIPTION
For example, this makes possible to specify the attributes for html tag and using external helpers to generate stylesheet links.
