### PR TITLE
if not canSelectImagesInContentEditable, prevent default on click

### DIFF
--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -81,7 +81,7 @@
 
     // --------- Make sure that images are selected when clicking on them ---------
     if (!browser.canSelectImagesInContentEditable()) {
-      dom.observe(element, "mousedown", function(event) {
+      dom.observe(element, "click", function(event) {
         var target = event.target;
         if (target.nodeName === "IMG") {
           that.selection.selectNode(target);


### PR DESCRIPTION
Because preventing default on mousedown forbids native
default behavior of being able to drag and drop images, which is so
nice to have for free.
Checked against chromium 24, still able to select IMG.
