### PR TITLE
Removing 'Heya!' console.log message

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -94,10 +94,6 @@
           this.toolbar = new wysihtml5.toolbar.Toolbar(this, this.config.toolbar);
         }
       });
-      
-      try {
-        console.log("Heya! This page is using wysihtml5 for rich text editing. Check out https://github.com/xing/wysihtml5");
-      } catch(e) {}
     },
     
     isCompatible: function() {


### PR DESCRIPTION
It's tacky. Addresses issue #332
