### PR TITLE
'src' attribute check method accepts data URL

### DIFF
--- a/dist/wysihtml5-0.4.0pre.js
+++ b/dist/wysihtml5-0.4.0pre.js
@@ -5074,7 +5074,7 @@ wysihtml5.dom.parse = (function() {
     })(),
 
     src: (function() {
-      var REG_EXP = /^(\/|https?:\/\/)/i;
+      var REG_EXP = /^((\/|https?:\/\/|")|data:image\/(gif|png|jpeg);base64,)/i;
       return function(attributeValue) {
         if (!attributeValue || !attributeValue.match(REG_EXP)) {
           return null;


### PR DESCRIPTION
Modified regular expression to match data URL for images encoded to base64.
Fixes [issue 334](https://github.com/xing/wysihtml5/issues/334)
