### PR TITLE
Wrap text outside of <p> in <p> when hitting enter with useLineBreaks==false

### DIFF
--- a/src/views/composer.js
+++ b/src/views/composer.js
@@ -365,7 +365,12 @@
 
       
       dom.observe(this.doc, "keydown", function(event) {
-        var keyCode = event.keyCode;
+        var keyCode       = event.keyCode,
+            blockElement  = dom.getParentElement(that.selection.getSelectedNode(), { nodeName: USE_NATIVE_LINE_BREAK_INSIDE_TAGS }, 4);
+
+        if (!blockElement && !that.config.useLineBreaks && keyCode === wysihtml5.ENTER_KEY) {
+          that.commands.exec("formatBlock", "p");
+        }
         
         if (event.shiftKey) {
           return;
@@ -375,7 +380,6 @@
           return;
         }
         
-        var blockElement = dom.getParentElement(that.selection.getSelectedNode(), { nodeName: USE_NATIVE_LINE_BREAK_INSIDE_TAGS }, 4);
         if (blockElement) {
           setTimeout(function() {
             // Unwrap paragraph after leaving a list or a H1-6
@@ -398,10 +402,7 @@
               adjust(selectedNode);
             }
           }, 0);
-          return;
-        }
-        
-        if (that.config.useLineBreaks && keyCode === wysihtml5.ENTER_KEY && !wysihtml5.browser.insertsLineBreaksOnReturn()) {
+        } else if (that.config.useLineBreaks && keyCode === wysihtml5.ENTER_KEY && !wysihtml5.browser.insertsLineBreaksOnReturn()) {
           that.commands.exec("insertLineBreak");
           event.preventDefault();
         }


### PR DESCRIPTION
Suppose that for some reason the body ends up like this (and it has for me):

``` html
<p>Hey</p>
Just testing|
```

Currently, when hitting return with the caret after `Just testing`, we end up with this:

``` html
<p>Hey</p>
Just testing<br>
|
```

Or worse (in Chrome), this:

``` html
<p>Hey</p>
Just testing
<div>|</div>
```

Using this fix, when `useLineBreaks == false`, the result will be a clean:

``` html
<p>Hey</p>
<p>Just testing</p>
<p>|<br></p>
```

(The `<br>` is just there to give the `<p>` some height, exactly as Wysihtml5 currently behaves when hitting enter from within a `<p>`.)

It also works great with Shift-Enter, in which case the result would be:

``` html
<p>Hey</p>
<p>Just testing<br>
|</p>
```
