### PR TITLE
Making the URL check also match mailto: links

### DIFF
--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -372,7 +372,7 @@ wysihtml5.dom.parse = (function() {
   // ------------ attribute checks ------------ \\
   var attributeCheckMethods = {
     url: (function() {
-      var REG_EXP = /^https?:\/\//i;
+      var REG_EXP = /^(https?:\/\/)|(mailto:)/i;
       return function(attributeValue) {
         if (!attributeValue || !attributeValue.match(REG_EXP)) {
           return null;


### PR DESCRIPTION
Using createLink with "mailto:" links was stripping them.
