### PR TITLE
I've added allow_attributes functionality.

### DIFF
--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -213,6 +213,7 @@ wysihtml5.dom.parse = (function() {
         addClass            = rule.add_class,             // add classes based on existing attributes
         setAttributes       = rule.set_attributes,        // attributes to set on the current node
         checkAttributes     = rule.check_attributes,      // check/convert values of attributes
+		allowAttributes		= rule.allow_attributes,      // allow attributes
         allowedClasses      = currentRules.classes,
         i                   = 0,
         classes             = [],
@@ -242,6 +243,17 @@ wysihtml5.dom.parse = (function() {
           attributes[attributeName] = newAttributeValue;
         }
       }
+    }
+	
+	if (allowAttributes) {
+        for (attributeName in allowAttributes) {
+        	alert(attributeName)
+          newAttributeValue = _getAttribute(oldNode, attributeName);
+        	
+          if(allowAttributes[attributeName]!=null  && newAttributeValue){
+	          attributes[attributeName] = newAttributeValue;
+          }
+       }
     }
     
     if (setClass) {


### PR DESCRIPTION
I found this function missing while using wysihtml5 with bootstrap (I found it within x-editable package so I first used it with bootstrap). I've added option to ignore declared attributes and it's support in parserRules. Forgive me my lack of github etiquette as I'm a new user here.

Add in parserRules "allow_attributes": {"data-toggle":1}to your tag declaration.

Signed-off-by: falxcerebri lukasz@groszkowski.pl
