### PR TITLE
Fix space key event issue with Japanese, Chinese (etc) IMEs in Chrome and Safari

### DIFF
--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -68,7 +68,7 @@
     });
 
     // --------- neword event ---------
-    dom.observe(element, "keyup", function(event) {
+    dom.observe(element, "keydown", function(event) {
       var keyCode = event.keyCode;
       if (keyCode === wysihtml5.SPACE_KEY || keyCode === wysihtml5.ENTER_KEY) {
         that.parent.fire("newword:composer");


### PR DESCRIPTION
This should fix #177 where when space bar is hit, the unfinished characters got inserted and interrupted the process of typing, choosing words.

The problem being, in Chrome and Safari, keyup event of SPACE_KEY will be triggered during the process of typing in IMEs that require choosing words before entering; however, in Firefox, keyup event of SPACE_KEY will NOT be triggered during such process, which is the ideal behaviour. 
Therefore simply changing **keyup** to **keydown** solves the problem. Tested in Chrome and Safari, keydown events of SPACE_KEY would not be triggered during typing, and the behaviour in Firefox stays the same. :blush: 
