### PR TITLE
Support for custom keyboard shortcuts

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -59,9 +59,15 @@
     // Whether the rich text editor should be rendered on touch devices (wysihtml5 >= 0.3.0 comes with basic support for iOS 5)
     supportTouchDevices:  true,
     // Whether senseless <span> elements (empty or without attributes) should be removed/replaced with their content
-    cleanUp:              true
+    cleanUp:              true,
+    // Set default keyboard shortcuts but allow developer to override
+    shortcuts: {
+        "66": "bold",     // B
+        "73": "italic",   // I
+        "85": "underline" // U
+    }
   };
-  
+
   wysihtml5.Editor = wysihtml5.lang.Dispatcher.extend(
     /** @scope wysihtml5.Editor.prototype */ {
     constructor: function(textareaElement, config) {

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -118,7 +118,8 @@
     // --------- Shortcut logic ---------
     dom.observe(element, "keydown", function(event) {
       var keyCode  = event.keyCode,
-          command  = shortcuts[keyCode];
+          shiftModifyer = event.shiftKey ? "shift+" : "",
+          command  = shortcuts[shiftModifyer+keyCode];
       if ((event.ctrlKey || event.metaKey) && !event.altKey && command) {
         var commandObj = that.commands.editor.toolbar.commandMapping[command + ":null"];
         // Show dialog when available

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -12,11 +12,7 @@
       /**
        * Map keyCodes to query commands
        */
-      shortcuts = {
-        "66": "bold",     // B
-        "73": "italic",   // I
-        "85": "underline" // U
-      };
+      shortcuts = {};
   
   wysihtml5.views.Composer.prototype.observe = function() {
     var that                = this,
@@ -24,7 +20,8 @@
         iframe              = this.sandbox.getIframe(),
         element             = this.element,
         focusBlurElement    = browser.supportsEventsInIframeCorrectly() ? element : this.sandbox.getWindow(),
-        pasteEvents         = ["drop", "paste"];
+        pasteEvents         = ["drop", "paste"],
+        shortcuts           = that.commands.editor.config.shortcuts;
 
     // --------- destroy:composer event ---------
     dom.observe(iframe, "DOMNodeRemoved", function() {
@@ -123,7 +120,13 @@
       var keyCode  = event.keyCode,
           command  = shortcuts[keyCode];
       if ((event.ctrlKey || event.metaKey) && !event.altKey && command) {
-        that.commands.exec(command);
+        var commandObj = that.commands.editor.toolbar.commandMapping[command + ":null"];
+        // Show dialog when available
+        if (commandObj && commandObj.dialog && !commandObj.state) {
+            commandObj.dialog.show();
+        } else {
+            that.commands.exec(command);
+        }
         event.preventDefault();
       }
     });


### PR DESCRIPTION
 Added support for keyboard shortcuts as a configuration option. Default values still present if not specified.

e.g. can now create an editor as follows:

var shortcuts = {
    "66": "bold",               // B
    "73": "italic",             // I
    "76": "createLink",         // L
    "78": "insertUnorderedList",// N
    "79": "insertOrderedList",  // O
    "85": "underline"           // U
};

var editor = new wysihtml5.Editor("body", { // id of textarea element
    toolbar:      "wysihtml5-toolbar", // id of toolbar element
    parserRules:  wysihtml5ParserRules, // defined in parser rules set
    useLineBreaks:  false,
    shortcuts: shortcuts
});

Added support for dialog commands from keyboard shortcuts, such as link.
