### PR TITLE
Replaces dangerous syntax with explicit undefineds.

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -12,11 +12,11 @@ wysihtml5.browser = (function() {
       isOpera     = userAgent.indexOf("Opera/")       !== -1;
   
   function iosVersion(userAgent) {
-    return +((/ipad|iphone|ipod/.test(userAgent) && userAgent.match(/ os (\d+).+? like mac os x/)) || [, 0])[1];
+    return +((/ipad|iphone|ipod/.test(userAgent) && userAgent.match(/ os (\d+).+? like mac os x/)) || [undefined, 0])[1];
   }
   
   function androidVersion(userAgent) {
-    return +(userAgent.match(/android (\d+)/) || [, 0])[1];
+    return +(userAgent.match(/android (\d+)/) || [undefined, 0])[1];
   }
   
   return {
@@ -296,7 +296,7 @@ wysihtml5.browser = (function() {
      *    }
      */
     supportsSpeechApiOn: function(input) {
-      var chromeVersion = userAgent.match(/Chrome\/(\d+)/) || [, 0];
+      var chromeVersion = userAgent.match(/Chrome\/(\d+)/) || [undefined, 0];
       return chromeVersion[1] >= 11 && ("onwebkitspeechchange" in input || "speech" in input);
     },
     


### PR DESCRIPTION
There are three locations where the code has [,0]. While this may be fine, you start running into problems if you generate the AST and try to walk it. I ran into an issue by trying to use browserify-shim + browserify with wysihtml. 
