### PR TITLE
Stop formatBlock addClass from adding spurious spaces to the class name string

### DIFF
--- a/src/commands/formatBlock.js
+++ b/src/commands/formatBlock.js
@@ -12,7 +12,7 @@
   function _addClass(element, className, classRegExp) {
     if (element.className) {
       _removeClass(element, classRegExp);
-      element.className += " " + className;
+      element.className = wysihtml5.lang.string(element.className + " " + className).trim();
     } else {
       element.className = className;
     }


### PR DESCRIPTION
When adding a new class to a block with an existing class Wysihtml5 will add an additional space to the class name string. 

This means it won't be recognised by subsequent calls to the state function of format block i.e. you won't be able to highlight the correct button when clicking inside that text.

Here is my use case, the catch all regex means that classes reset each other:

```
wysihtml5.commands.customH1 = {
  exec: function(composer, command, className) {
    return wysihtml5.commands.formatBlock.exec(composer, command, "h1", className, /.*/);
  },
  state: function(composer, command, className) {
    return wysihtml5.commands.formatBlock.state(composer, command, "h1", className, /.*/);
  }
};
```
