### PR TITLE
fix check_attribute parser rule to only set attribute if already set

### DIFF
--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -231,15 +231,18 @@ wysihtml5.dom.parse = (function() {
       attributes = wysihtml5.lang.object(setAttributes).clone();
     }
     
-    if (checkAttributes) {
+     if (checkAttributes) {
       for (attributeName in checkAttributes) {
         method = attributeCheckMethods[checkAttributes[attributeName]];
         if (!method) {
           continue;
         }
-        newAttributeValue = method(_getAttribute(oldNode, attributeName));
-        if (typeof(newAttributeValue) === "string") {
-          attributes[attributeName] = newAttributeValue;
+        oldAttribute = _getAttribute(oldNode, attributeName);
+        if (oldAttribute) {
+          newAttributeValue = method(oldAttribute);
+          if (typeof(newAttributeValue) === "string") {
+            attributes[attributeName] = newAttributeValue;
+          }
         }
       }
     }


### PR DESCRIPTION
Previously, if you set a check_attribute for a given attribute, it would set that attribute even if it wasn't already set. This can clutter up the attributes of the markup quite a bit if you are trying to add custom attributes that will be validated, but you don't want them to show up on every one of those types of tags. 

This fix skips validation for check_attribute if the attribute itself is not set at all. 
