### PR TITLE
"url", "src", and "href" parser rules allow values to begin with "//".

### DIFF
--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -372,7 +372,7 @@ wysihtml5.dom.parse = (function() {
   // ------------ attribute checks ------------ \\
   var attributeCheckMethods = {
     url: (function() {
-      var REG_EXP = /^https?:\/\//i;
+      var REG_EXP = /^(https?:)?\/\//i;
       return function(attributeValue) {
         if (!attributeValue || !attributeValue.match(REG_EXP)) {
           return null;
@@ -384,7 +384,7 @@ wysihtml5.dom.parse = (function() {
     })(),
 
     src: (function() {
-      var REG_EXP = /^(\/|https?:\/\/)/i;
+      var REG_EXP = /^(\/\/?|https?:\/\/)/i;
       return function(attributeValue) {
         if (!attributeValue || !attributeValue.match(REG_EXP)) {
           return null;
@@ -396,7 +396,7 @@ wysihtml5.dom.parse = (function() {
     })(),
 
     href: (function() {
-      var REG_EXP = /^(\/|https?:\/\/|mailto:)/i;
+      var REG_EXP = /^(\/\/?|https?:\/\/|mailto:)/i;
       return function(attributeValue) {
         if (!attributeValue || !attributeValue.match(REG_EXP)) {
           return null;

--- a/test/dom/parse_test.js
+++ b/test/dom/parse_test.js
@@ -121,11 +121,15 @@ if (wysihtml5.browser.supported()) {
     this.equal(
       this.sanitize(
         '<img src="http://url.gif">' +
+        '<img src="//same_protocol.gif">' +
         '<img src="/path/to/absolute%20href.gif">' +
         '<img src="mango time">',
         rules
       ),
-      '<img src="http://url.gif"><img><img>'
+      '<img src="http://url.gif">' +
+      '<img src="//same_protocol.gif">' +
+      '<img>' +
+      '<img>'
     );
   });
 
@@ -142,12 +146,14 @@ if (wysihtml5.browser.supported()) {
       this.sanitize(
         '<img src="HTTP://url.gif">' +
         '<img src="/path/to/absolute%20href.gif">' +
+        '<img src="//same_protocol.gif">' +
         '<img src="mailto:christopher@foobar.com">' +
         '<img src="mango time">',
         rules
       ),
       '<img src="http://url.gif">' +
       '<img src="/path/to/absolute%20href.gif">' +
+      '<img src="//same_protocol.gif">' +
       '<img>' +
       '<img>'
     );
@@ -167,6 +173,7 @@ if (wysihtml5.browser.supported()) {
         '<a href="/foobar"></a>' +
         '<a href="HTTPS://google.com"></a>' +
         '<a href="http://google.com"></a>' +
+        '<a href="//google.com"></a>' +
         '<a href="MAILTO:christopher@foobar.com"></a>' +
         '<a href="mango time"></a>' +
         '<a href="ftp://google.com"></a>',
@@ -175,6 +182,7 @@ if (wysihtml5.browser.supported()) {
       '<a href="/foobar"></a>' +
       '<a href="https://google.com"></a>' +
       '<a href="http://google.com"></a>' +
+      '<a href="//google.com"></a>' +
       '<a href="mailto:christopher@foobar.com"></a>' +
       '<a></a>' +
       '<a></a>'


### PR DESCRIPTION
This is necessary because many URLs omit the protocol. E.g.
`<a href="//foo.com">`

Note: The updated tests pass.
