### PR TITLE
Remove unprofessional console.log spam.

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -94,10 +94,6 @@
           this.toolbar = new wysihtml5.toolbar.Toolbar(this, this.config.toolbar);
         }
       });
-      
-      try {
-        console.log("Heya! This page is using wysihtml5 for rich text editing. Check out https://github.com/xing/wysihtml5");
-      } catch(e) {}
     },
     
     isCompatible: function() {


### PR DESCRIPTION
The spam message is not something that you are waiting to see when you open your console. Imagine all plugins doing this: "Thanks for using this plugin, please buy Coca Cola."
