### PR TITLE
Ensure the dialog interpolate interval is clear before setting a new one

### DIFF
--- a/src/toolbar/dialog.js
+++ b/src/toolbar/dialog.js
@@ -173,6 +173,7 @@
       this._observe();
       this._interpolate();
       if (elementToChange) {
+        if (this.interval) clearInterval(this.interval);
         this.interval = setInterval(function() { that._interpolate(true); }, 500);
       }
       dom.addClass(this.link, CLASS_NAME_OPENED);


### PR DESCRIPTION
Previously, if the user had a link dialog already open and clicked on another link in the editor, the interpolate interval would never get cleared and it's handle would get overwritten. This patch checks to see if an interval is already defined and clears it before setting another interval.
